### PR TITLE
Remove Max Imbalance

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -95,7 +95,6 @@ contract LeveragedPool is ILeveragedPool, AccessControl, Initializable {
 
   function commit(
     CommitType commitType,
-    bytes16 maxImbalance,
     uint112 amount
   ) external override {
     require(amount > 0, "Amount must not be zero");
@@ -103,7 +102,6 @@ contract LeveragedPool is ILeveragedPool, AccessControl, Initializable {
 
     commits[commitIDCounter] = Commit({
       commitType: commitType,
-      maxImbalance: maxImbalance,
       amount: amount,
       owner: msg.sender,
       created: uint40(block.timestamp)
@@ -111,7 +109,7 @@ contract LeveragedPool is ILeveragedPool, AccessControl, Initializable {
 
     shadowPools[commitType] = shadowPools[commitType].add(amount);
 
-    emit CreateCommit(commitIDCounter, amount, maxImbalance, commitType);
+    emit CreateCommit(commitIDCounter, amount, commitType);
 
     if (
       commitType == CommitType.LongMint || commitType == CommitType.ShortMint
@@ -226,13 +224,6 @@ contract LeveragedPool is ILeveragedPool, AccessControl, Initializable {
         "Transfer failed"
       );
     }
-    require(
-      PoolSwapLibrary.compareDecimals(
-        PoolSwapLibrary.getRatio(longBalance, shortBalance),
-        _commit.maxImbalance
-      ) <= 0,
-      "Imbalance tolerance exceeded"
-    );
   }
 
   /**

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -10,7 +10,6 @@ interface ILeveragedPool {
   enum CommitType { ShortMint, ShortBurn, LongMint, LongBurn }
 
   struct Commit {
-    bytes16 maxImbalance;
     uint112 amount;
     CommitType commitType;
     uint40 created;
@@ -36,13 +35,11 @@ interface ILeveragedPool {
     @notice Creates a notification when a commit is created in the pool
     @param commitID The id of the new commit
     @param amount The amount of tokens committed
-    @param maxImbalance The max imbalance between the pairs that the commit will tolerate
     @param commitType The commitment type
    */
   event CreateCommit(
     uint128 indexed commitID,
     uint128 indexed amount,
-    bytes16 indexed maxImbalance,
     CommitType commitType
   );
 
@@ -102,12 +99,10 @@ interface ILeveragedPool {
   /**
     @notice Creates a commitment to mint or burn
     @param commitType Valid types are SB,SM, LB, LM. Each type contains position (Short, Long) and action (Mint, Burn).
-    @param maxImbalance The max imbalance between their target pool and its inverse. Imbalance is defined as longBalance / shortBalance
     @param amount the amount of the quote token that they wish to commit to a transaction
      */
   function commit(
     CommitType commitType,
-    bytes16 maxImbalance,
     uint112 amount
   ) external;
 

--- a/documentation/contract-reference.md
+++ b/documentation/contract-reference.md
@@ -226,14 +226,12 @@ Emitted when a newly deployed pool is initialized. A pool that isn't initialized
 event CreateCommit(
   uint128 indexed commitID,
   uint128 indexed amount,
-  bytes16 indexed maxImbalance,
   CommitType commitType
 );
 ```  
 Emitted when a commit is created. This forms the user's record of commits, as the commit details are not retrievable without the commit ID.
 - `commitID` The ID of the commit, to be used when withdrawing or executing the commit.
 - `amount` The amount that was committed
-- `maxImbalance` The difference between the pools that the user-specified. If the commit is executed and this is smaller than the resulting difference, the transaction will revert.
 - `commitType` The type of commit (long burn, short burn, long mint, short mint)
 
 #### RemoveCommit
@@ -288,12 +286,10 @@ Initializes a minimal clone of a pool contract. This can only be run once. Ordin
 ```
 function commit(
     CommitType commitType,
-    bytes16 maxImbalance,
     uint112 amount
   ) external;
 ```  
 Used to create a commitment to add or remove funds from one of the pool's pairs.
-- `maxImbalance` The maximum difference between the pools that the user will tolerate. This is the ratio between the long and the short live balances. The value should be generated using the `PoolSwapLibrary.getRatio` method.
 
 #### uncommit
 ```

--- a/test/LeveragedPool/executeCommitment/baseCases.spec.ts
+++ b/test/LeveragedPool/executeCommitment/baseCases.spec.ts
@@ -31,7 +31,6 @@ const updateInterval = 2;
 const frontRunningInterval = 1; // seconds
 const fee = "0x00000000000000000000000000000000";
 const leverage = 2;
-let imbalance: BytesLike;
 const commitType = [2]; //long mint;
 
 describe("LeveragedPool - executeCommitment: Basic test cases", () => {
@@ -55,44 +54,19 @@ describe("LeveragedPool - executeCommitment: Basic test cases", () => {
       signers = result.signers;
       token = result.token;
       library = result.library;
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("50"),
-        ethers.utils.parseEther("10")
-      );
     });
     it("should revert if the commitment is too new", async () => {
       await token.approve(pool.address, amountCommitted);
       const commit = await createCommit(
         pool,
         commitType,
-        imbalance,
         amountCommitted
       );
       await expect(
         pool.executeCommitment([commit.commitID])
       ).to.be.rejectedWith(Error);
     });
-    it("should revert if the max imbalance is less than the current imbalance of the pairs", async () => {
-      await token.approve(pool.address, amountCommitted.mul(2));
-      const commit = await createCommit(
-        pool,
-        commitType,
-        imbalance,
-        amountCommitted
-      );
-      await timeout(6000); // wait six seconds
-      await pool.executePriceChange(5, 500);
-      await pool.executeCommitment([commit.commitID]);
-      const commit2 = await createCommit(
-        pool,
-        commitType,
-        imbalance,
-        amountCommitted
-      );
-      await expect(
-        pool.executeCommitment([commit2.commitID])
-      ).to.be.rejectedWith(Error);
-    });
+
     it("should revert if the commitment doesn't exist", async () => {
       await expect(pool.executeCommitment([9])).to.be.rejectedWith(Error);
     });
@@ -115,13 +89,8 @@ describe("LeveragedPool - executeCommitment: Basic test cases", () => {
       token = result.token;
       library = result.library;
 
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("5"),
-        ethers.utils.parseEther("2")
-      );
-
       await token.approve(pool.address, amountCommitted);
-      commit = await createCommit(pool, commitType, imbalance, amountCommitted);
+      commit = await createCommit(pool, commitType, amountCommitted);
     });
 
     it("should remove the commitment after execution", async () => {

--- a/test/LeveragedPool/executeCommitment/longBurn.spec.ts
+++ b/test/LeveragedPool/executeCommitment/longBurn.spec.ts
@@ -30,7 +30,6 @@ const updateInterval = 2;
 const frontRunningInterval = 1; // seconds
 const fee = "0x00000000000000000000000000000000";
 const leverage = 2;
-let imbalance: BytesLike;
 
 describe("LeveragedPool - executeCommitment: Long Burn", () => {
   let token: TestToken;
@@ -56,17 +55,13 @@ describe("LeveragedPool - executeCommitment: Long Burn", () => {
       token = result.token;
       library = result.library;
       longToken = result.longToken;
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("300"),
-        ethers.utils.parseEther("50")
-      );
       await token.approve(pool.address, amountMinted);
-      commit = await createCommit(pool, [2], imbalance, amountCommitted);
+      commit = await createCommit(pool, [2], amountCommitted);
       await timeout(2000);
       await pool.executePriceChange(9, 10);
       await pool.executeCommitment([commit.commitID]);
       await longToken.approve(pool.address, amountCommitted);
-      commit = await createCommit(pool, [3], imbalance, amountCommitted);
+      commit = await createCommit(pool, [3], amountCommitted);
     });
     it("should adjust the live long pool balance", async () => {
       expect(await pool.longBalance()).to.eq(amountCommitted);

--- a/test/LeveragedPool/executeCommitment/longMint.spec.ts
+++ b/test/LeveragedPool/executeCommitment/longMint.spec.ts
@@ -30,7 +30,6 @@ const updateInterval = 2;
 const frontRunningInterval = 1; // seconds
 const fee = "0x00000000000000000000000000000000";
 const leverage = 2;
-let imbalance: BytesLike;
 
 describe("LeveragedPool - executeCommitment: Long Mint", () => {
   let token: TestToken;
@@ -54,13 +53,9 @@ describe("LeveragedPool - executeCommitment: Long Mint", () => {
       signers = result.signers;
       token = result.token;
       library = result.library;
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("100"),
-        ethers.utils.parseEther("23")
-      );
       longToken = result.longToken;
       await token.approve(pool.address, amountMinted);
-      commit = await createCommit(pool, [2], imbalance, amountCommitted);
+      commit = await createCommit(pool, [2], amountCommitted);
     });
     it("should adjust the live long pool balance", async () => {
       expect(await pool.longBalance()).to.eq(0);

--- a/test/LeveragedPool/executeCommitment/multipleCommitments.spec.ts
+++ b/test/LeveragedPool/executeCommitment/multipleCommitments.spec.ts
@@ -31,7 +31,6 @@ const updateInterval = 2;
 const frontRunningInterval = 1; // seconds
 const fee = "0x00000000000000000000000000000000";
 const leverage = 1;
-let imbalance: BytesLike;
 
 describe("LeveragedPool - executeCommitment:  Multiple commitments", () => {
   let token: TestToken;
@@ -53,17 +52,13 @@ describe("LeveragedPool - executeCommitment:  Multiple commitments", () => {
       );
       pool = result.pool;
       library = result.library;
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("10"),
-        ethers.utils.parseEther("5")
-      );
 
       token = result.token;
       shortToken = result.shortToken;
 
       await token.approve(pool.address, amountMinted);
 
-      const commit = await createCommit(pool, [2], imbalance, amountCommitted);
+      const commit = await createCommit(pool, [2], amountCommitted);
 
       await shortToken.approve(pool.address, amountMinted);
       await timeout(2000);
@@ -71,9 +66,9 @@ describe("LeveragedPool - executeCommitment:  Multiple commitments", () => {
       await pool.executePriceChange(lastPrice, lastPrice + 10);
       await pool.executeCommitment([commit.commitID]);
 
-      commits.push(await createCommit(pool, [2], imbalance, amountCommitted));
+      commits.push(await createCommit(pool, [2], amountCommitted));
       commits.push(
-        await createCommit(pool, [3], imbalance, amountCommitted.div(2))
+        await createCommit(pool, [3], amountCommitted.div(2))
       );
     });
     it("should reduce the balances of the shadows pools involved", async () => {
@@ -116,17 +111,13 @@ describe("LeveragedPool - executeCommitment:  Multiple commitments", () => {
       );
       pool = result.pool;
       library = result.library;
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("10"),
-        ethers.utils.parseEther("5")
-      );
 
       token = result.token;
       shortToken = result.shortToken;
 
       await token.approve(pool.address, amountMinted);
 
-      const commit = await createCommit(pool, [0], imbalance, amountCommitted);
+      const commit = await createCommit(pool, [0], amountCommitted);
 
       await shortToken.approve(pool.address, amountMinted);
       await timeout(2000);
@@ -134,9 +125,9 @@ describe("LeveragedPool - executeCommitment:  Multiple commitments", () => {
       await pool.executePriceChange(lastPrice, 10);
       await pool.executeCommitment([commit.commitID]);
 
-      commits.push(await createCommit(pool, [0], imbalance, amountCommitted));
+      commits.push(await createCommit(pool, [0], amountCommitted));
       commits.push(
-        await createCommit(pool, [1], imbalance, amountCommitted.div(2))
+        await createCommit(pool, [1], amountCommitted.div(2))
       );
     });
     it("should reduce the balances of the shadows pools involved", async () => {

--- a/test/LeveragedPool/executeCommitment/shortBurn.spec.ts
+++ b/test/LeveragedPool/executeCommitment/shortBurn.spec.ts
@@ -30,7 +30,6 @@ const updateInterval = 2;
 const frontRunningInterval = 1; // seconds
 const fee = "0x00000000000000000000000000000000";
 const leverage = 2;
-let imbalance: BytesLike;
 
 describe("LeveragedPool - executeCommitment: Short Burn", () => {
   let token: TestToken;
@@ -56,18 +55,14 @@ describe("LeveragedPool - executeCommitment: Short Burn", () => {
       token = result.token;
       shortToken = result.shortToken;
       library = result.library;
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("10"),
-        ethers.utils.parseEther("5")
-      );
       await token.approve(pool.address, amountMinted);
-      commit = await createCommit(pool, [0], imbalance, amountCommitted);
+      commit = await createCommit(pool, [0], amountCommitted);
       await timeout(2000);
       await pool.executePriceChange(lastPrice, 10);
       await pool.executeCommitment([commit.commitID]);
 
       await shortToken.approve(pool.address, amountCommitted);
-      commit = await createCommit(pool, [1], imbalance, amountCommitted);
+      commit = await createCommit(pool, [1], amountCommitted);
     });
     it("should reduce the live short pool balance", async () => {
       expect(await pool.shortBalance()).to.eq(amountCommitted);

--- a/test/LeveragedPool/executeCommitment/shortMint.spec.ts
+++ b/test/LeveragedPool/executeCommitment/shortMint.spec.ts
@@ -30,7 +30,6 @@ const updateInterval = 2;
 const frontRunningInterval = 1; // seconds
 const fee = "0x00000000000000000000000000000000";
 const leverage = 2;
-let imbalance: BytesLike;
 
 describe("LeveragedPool - executeCommitment: Short Mint", () => {
   let token: TestToken;
@@ -55,12 +54,8 @@ describe("LeveragedPool - executeCommitment: Short Mint", () => {
       token = result.token;
       shortToken = result.shortToken;
       library = result.library;
-      imbalance = await library.getRatio(
-        ethers.utils.parseEther("100"),
-        ethers.utils.parseEther("23")
-      );
       await token.approve(pool.address, amountMinted);
-      commit = await createCommit(pool, [0], imbalance, amountCommitted);
+      commit = await createCommit(pool, [0], amountCommitted);
     });
     it("should adjust the live short pool balance", async () => {
       expect(await pool.shortBalance()).to.eq(0);

--- a/test/LeveragedPool/executePriceChange.spec.ts
+++ b/test/LeveragedPool/executePriceChange.spec.ts
@@ -23,7 +23,6 @@ const fee = "0x3ff947ae147ae147ae147ae147ae147a"; // 2% per execution. An IEEE 7
 const lastPrice = 77000000;
 const frontRunningInterval = 1;
 const leverage = 10;
-let imbalance: BytesLike;
 
 let library: PoolSwapLibrary;
 let pool: LeveragedPool;
@@ -54,11 +53,8 @@ const setupHook = async () => {
  * Adds 2000 quote tokens to each pool
  */
 const fundPools = async () => {
-  imbalance = await library.convertUIntToDecimal(
-    ethers.utils.parseEther("2001")
-  );
-  const shortMint = await createCommit(pool, [0], imbalance, amountCommitted);
-  const longMint = await createCommit(pool, [2], imbalance, amountCommitted);
+  const shortMint = await createCommit(pool, [0], amountCommitted);
+  const longMint = await createCommit(pool, [2], amountCommitted);
   await timeout(2000);
   await pool.executePriceChange(1, lastPrice);
   await pool.executeCommitment([shortMint.commitID, longMint.commitID]);

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -144,29 +144,25 @@ export const deployPoolAndTokenContracts = async (
 export interface CommitEventArgs {
   commitID: BigNumberish;
   amount: BigNumberish;
-  maxImbalance: BigNumberish;
   commitType: BigNumberish;
 }
 /**
  * Creates a commit and returns the event arguments for it
  * @param pool The pool contract instance
  * @param commitType The type of commit
- * @param imbalance The max imbalance for the commit
  * @param amount The amount to commit to
  */
 export const createCommit = async (
   pool: LeveragedPool,
   commitType: BigNumberish,
-  imbalance: BytesLike,
   amount: BigNumberish
 ): Promise<CommitEventArgs> => {
   const receipt = await (
-    await pool.commit(commitType, imbalance, amount)
+    await pool.commit(commitType, amount)
   ).wait();
   return {
     commitID: getEventArgs(receipt, "CreateCommit")?.commitID,
     amount: getEventArgs(receipt, "CreateCommit")?.amount,
-    maxImbalance: getEventArgs(receipt, "CreateCommit")?.maxImbalance,
     commitType: getEventArgs(receipt, "CreateCommit")?.commitType,
   };
 };


### PR DESCRIPTION
# Motivation
For 1.0.0 Poolswaps it was decided we wouldn't included max imbalance. This was to simplify some of the keeper mechanisms.

# Changes
- removes all references to max imbalance