### PR TITLE
Test token owner

### DIFF
--- a/contracts/implementation/PoolToken.sol
+++ b/contracts/implementation/PoolToken.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "../vendors/ERC20_Cloneable.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 
 /*
-@title The pool token
-*/
-contract PoolToken is ERC20_Cloneable, Ownable {
+ * @title The pool token
+ * @dev ERC_20_Cloneable contains onlyOwner code implemented for use with the cloneable setup
+ */
+contract PoolToken is ERC20_Cloneable {
     // #### Global state
 
     // #### Functions

--- a/contracts/interfaces/IPoolKeeper.sol
+++ b/contracts/interfaces/IPoolKeeper.sol
@@ -79,7 +79,12 @@ interface IPoolKeeper {
      * @param _poolCode The code associated with this pool.
      * @param _poolAddress The address of the newly-created pool.
      */
-    function newPool(string calldata _poolCode, address _poolAddress) external;
+    function newPool(
+        string memory _poolCode,
+        address _poolAddress,
+        address _quoteToken,
+        address _oracleWrapper
+    ) external;
 
     /**
      * @notice Sets the factory of the keeper contract
@@ -113,4 +118,13 @@ interface IPoolKeeper {
      * @param poolCodes pool codes to perform the update for.
      */
     function performUpkeepMultiplePools(address[] calldata poolCodes) external;
+
+    /**
+     * @notice Getter for the poolIdTaken mapping
+     */
+    function poolIdTaken(
+        string calldata poolCode,
+        address quoteToken,
+        address oracleWrapper
+    ) external view returns (bool);
 }

--- a/contracts/vendors/ERC20_Cloneable.sol
+++ b/contracts/vendors/ERC20_Cloneable.sol
@@ -6,7 +6,6 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/proxy/Initializable.sol";
-import "@openzeppelin/contracts/access/AccessControl.sol";
 
 /**
  * @dev Minimal Clones compatible implementation of the {IERC20} interface.
@@ -33,9 +32,7 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
  * functions have been added to mitigate the well-known issues around setting
  * allowances. See {IERC20-approve}.
  */
-contract ERC20_Cloneable is Context, IERC20, AccessControl, Initializable {
-    bytes32 public constant POOL = keccak256("POOL");
-
+contract ERC20_Cloneable is Context, IERC20, Initializable {
     using SafeMath for uint256;
 
     mapping(address => uint256) private _balances;
@@ -47,6 +44,7 @@ contract ERC20_Cloneable is Context, IERC20, AccessControl, Initializable {
     string private _name;
     string private _symbol;
     uint8 private _decimals;
+    address public owner;
 
     /**
      * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
@@ -68,7 +66,7 @@ contract ERC20_Cloneable is Context, IERC20, AccessControl, Initializable {
         string memory name_,
         string memory symbol_
     ) external initializer {
-        _setupRole(POOL, _pool);
+        owner = _pool;
         _name = name_;
         _symbol = symbol_;
         _decimals = 18;
@@ -343,4 +341,17 @@ contract ERC20_Cloneable is Context, IERC20, AccessControl, Initializable {
         address to,
         uint256 amount
     ) internal virtual {}
+
+    /**
+     * @notice Transfer ownership. Implemented to help with initializable
+     */
+    function transferOwnership(address _owner) external onlyOwner {
+        require(_owner != address(0), "Owner: setting to 0 address");
+        owner = _owner;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "msg.sender not owner");
+        _;
+    }
 }

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -137,11 +137,13 @@ describe("PoolFactory - deployPool", () => {
     it("pool should own tokens", async () => {
         const longToken = await pool.tokens(0)
         const shortToken = await pool.tokens(1)
-        let tokenInstance = new ethers.Contract(longToken, PoolToken__factory.abi).connect((await ethers.getSigners())[0])
+        let tokenInstance = new ethers.Contract(
+            longToken,
+            PoolToken__factory.abi
+        ).connect((await ethers.getSigners())[0])
         expect(await tokenInstance.owner()).to.eq(pool.address)
 
         tokenInstance = tokenInstance.attach(shortToken)
         expect(await tokenInstance.owner()).to.eq(pool.address)
-
     })
 })


### PR DESCRIPTION
# Motivation
Check that the pool owns the token after PoolDeploy

*Edit
Fixes the failing test by updating the ownership flow in deployment. Also fixes a potential bug with cloneable pools and tokens. Pools are now uniquely identified by their poolCode, quoteToken and oracleWrapper

# Changes
- add ownership test
- remove roles from ERC20_Cloneable
- add ownership to ERC20_Cloneable
- add safety checks on deployment params to avoid clashes