### PR TITLE
Fix unlocked pragmas in contracts 

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import "../interfaces/ILeveragedPool.sol";

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import "../interfaces/IPoolFactory.sol";

--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import "../interfaces/IPoolKeeper.sol";

--- a/contracts/implementation/PoolSwapLibrary.sol
+++ b/contracts/implementation/PoolSwapLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 import "abdk-libraries-solidity/ABDKMathQuad.sol";
 

--- a/contracts/implementation/PoolToken.sol
+++ b/contracts/implementation/PoolToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import "../vendors/ERC20_Cloneable.sol";

--- a/contracts/implementation/TestOracleWrapper.sol
+++ b/contracts/implementation/TestOracleWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import "../interfaces/IOracleWrapper.sol";

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 /*

--- a/contracts/interfaces/IOracleWrapper.sol
+++ b/contracts/interfaces/IOracleWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 /**

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 /**

--- a/contracts/interfaces/IPoolKeeper.sol
+++ b/contracts/interfaces/IPoolKeeper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 /*

--- a/contracts/test-utilities/IChainlinkOracle.sol
+++ b/contracts/test-utilities/IChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 
 /**
  * This interface follows the AggregatorV3 interface. The getRoundData has been excluded as only the

--- a/contracts/test-utilities/TestChainlinkOracle.sol
+++ b/contracts/test-utilities/TestChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 
 /**
  * @dev The following is a mock Chainlink Price Feed Implementation.

--- a/contracts/test-utilities/TestERC20.sol
+++ b/contracts/test-utilities/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/test-utilities/TestOracle.sol
+++ b/contracts/test-utilities/TestOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 /*

--- a/contracts/test-utilities/TestPoolFactory.sol
+++ b/contracts/test-utilities/TestPoolFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import "../implementation/LeveragedPool.sol";

--- a/contracts/vendors/ERC20_Cloneable.sol
+++ b/contracts/vendors/ERC20_Cloneable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity 0.7.6;
 
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/vendors/SafeMath_112.sol
+++ b/contracts/vendors/SafeMath_112.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 /**
  * @title UInt112 variant of Openzeppelin SafeMath

--- a/contracts/vendors/SafeMath_128.sol
+++ b/contracts/vendors/SafeMath_128.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 /**
  * @title UInt128 variant of Openzeppelin SafeMath

--- a/contracts/vendors/SafeMath_32.sol
+++ b/contracts/vendors/SafeMath_32.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 /**
  * @title UInt32 variant of Openzeppelin SafeMath

--- a/contracts/vendors/SafeMath_40.sol
+++ b/contracts/vendors/SafeMath_40.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 /**
  * @title UInt40 variant of Openzeppelin SafeMath


### PR DESCRIPTION
# Motivation
Locking the pragma helps ensure that contracts do not accidentally get deployed using a different compiler version with which they have been tested the most.

# Changes
- Set Solidity version to 0.7.6 across all of the contracts