### PR TITLE
[RAJEEV18] Cache fee variable to elide SLOAD

### DIFF
--- a/contracts/implementation/PriceChanger.sol
+++ b/contracts/implementation/PriceChanger.sol
@@ -45,11 +45,12 @@ contract PriceChanger is IPriceChanger, Ownable {
         bytes16 leverageAmount = ILeveragedPool(leveragedPool).leverageAmount();
 
         // Calculate fees from long and short sides
+        bytes16 sharedFee = fee;
         uint112 longFeeAmount = uint112(
-            PoolSwapLibrary.convertDecimalToUInt(PoolSwapLibrary.multiplyDecimalByUInt(fee, longBalance))
+            PoolSwapLibrary.convertDecimalToUInt(PoolSwapLibrary.multiplyDecimalByUInt(sharedFee, longBalance))
         );
         uint112 shortFeeAmount = uint112(
-            PoolSwapLibrary.convertDecimalToUInt(PoolSwapLibrary.multiplyDecimalByUInt(fee, shortBalance))
+            PoolSwapLibrary.convertDecimalToUInt(PoolSwapLibrary.multiplyDecimalByUInt(sharedFee, shortBalance))
         );
         uint112 totalFeeAmount = 0;
         if (shortBalance >= shortFeeAmount) {


### PR DESCRIPTION
# Issue
RAJEEV18

# Changes
 - Cache `fee` into `sharedFee` variable in order to avoid `SLOAD` instruction (at the expense of readability)