### PR TITLE
[RAJEEV36] Call `_executePriceChange` last in `performUpkeepSinglePool`

### DIFF
--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -115,6 +115,11 @@ contract PoolKeeper is IPoolKeeper, Ownable {
 
         emit NewRound(lastExecutionPrice[_pool], latestPrice, pool.updateInterval(), _pool);
 
+        uint256 gasSpent = startGas - gasleft();
+        uint256 _gasPrice = 1; /* TODO: poll gas price oracle (or BASEFEE) */
+
+        payKeeper(_pool, _gasPrice, gasSpent);
+
         _executePriceChange(
             uint32(block.timestamp),
             pool.updateInterval(),
@@ -122,11 +127,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
             lastExecutionPrice[_pool],
             executionPrice[_pool]
         );
-
-        uint256 gasSpent = startGas - gasleft();
-        uint256 _gasPrice = 1; /* TODO: poll gas price oracle (or BASEFEE) */
-
-        payKeeper(_pool, _gasPrice, gasSpent);
     }
 
     /**


### PR DESCRIPTION
# Issue
RAJEEV36

# Changes
 - Move call to `_executePriceChange` to the end of `performUpkeepSinglePool` in order to preserve keeper rewards logic
