### PR TITLE
[RAJEEV-02] emit the local variables in initialize rather than state vars

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -69,7 +69,12 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         tokens[1] = initialization._shortToken;
         priceChanger = initialization._priceChanger;
         poolCommitter = initialization._poolCommitter;
-        emit PoolInitialized(tokens[0], tokens[1], initialization._quoteToken, initialization._poolCode);
+        emit PoolInitialized(
+            initialization._longToken,
+            initialization._shortToken,
+            initialization._quoteToken,
+            initialization._poolCode
+        );
     }
 
     /**


### PR DESCRIPTION
# Motivation
Rajeev02
Avoid doing unnecessary SLOADs

# Changes
emit `initialization._longToken` instead of `tokens[0]` and same for short token