### PR TITLE
Cache commitIDCounter locally on commit

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -35,10 +35,11 @@ contract PoolCommitter is IPoolCommitter, Ownable {
 
     function commit(CommitType commitType, uint112 amount) external override {
         require(amount > 0, "Amount must not be zero");
-        commitIDCounter = commitIDCounter + 1;
+        uint128 currentCommitIDCounter = commitIDCounter;
+        commitIDCounter = currentCommitIDCounter + 1;
 
         // create commitment
-        commits[commitIDCounter] = Commit({
+        commits[currentCommitIDCounter] = Commit({
             commitType: commitType,
             amount: amount,
             owner: msg.sender,
@@ -48,11 +49,11 @@ contract PoolCommitter is IPoolCommitter, Ownable {
         shadowPools[_commitType] = shadowPools[_commitType] + amount;
 
         if (earliestCommitUnexecuted == NO_COMMITS_REMAINING) {
-            earliestCommitUnexecuted = commitIDCounter;
+            earliestCommitUnexecuted = currentCommitIDCounter;
         }
-        latestCommitUnexecuted = commitIDCounter;
+        latestCommitUnexecuted = currentCommitIDCounter;
 
-        emit CreateCommit(commitIDCounter, amount, commitType);
+        emit CreateCommit(currentCommitIDCounter, amount, commitType);
 
         // pull in tokens
         if (commitType == CommitType.LongMint || commitType == CommitType.ShortMint) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "build": "npm run clean && npm run compile",
         "clean": "npx hardhat clean",
+        "refresh": "rm -rf artifacts/ typechain && yarn compile && npx hardhat typechain",
         "compile": "npx hardhat compile",
         "test": "npx hardhat test",
         "coverage": "npm run build && npx hardhat coverage --temp artifacts --network coverage",

--- a/test/PoolCommitter/commit.spec.ts
+++ b/test/PoolCommitter/commit.spec.ts
@@ -136,11 +136,9 @@ describe("LeveragedPool - commit", () => {
             expect(getEventArgs(receipt, "CreateCommit")?.amount).to.eq(
                 amountCommitted
             )
-            expect(
-                getEventArgs(receipt, "CreateCommit")?.commitID.gt(
-                    ethers.BigNumber.from(0)
-                )
-            ).to.eq(true)
+            expect(getEventArgs(receipt, "CreateCommit")?.commitID).to.equal(
+                ethers.BigNumber.from(0)
+            )
         })
     })
 


### PR DESCRIPTION
# Motivation
Addresses Rajeev-04 and Rajeev-05

# Changes
- Cache `commitIDCounter` at the start of `commit`, to save on SLOADs.