### PR TITLE
[Rajeev-06] Use safeTransferFrom instead of transferFrom & remove unnecessary req

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -6,6 +6,7 @@ import "../interfaces/IPoolCommitter.sol";
 import "./PoolToken.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "./PoolSwapLibrary.sol";
 import "../interfaces/IOracleWrapper.sol";
@@ -14,6 +15,7 @@ import "../interfaces/IOracleWrapper.sol";
 @title The pool controller contract
 */
 contract LeveragedPool is ILeveragedPool, Initializable {
+    using SafeERC20 for IERC20;
     // #### Globals
 
     // Each balance is the amount of quote tokens in the pair
@@ -105,7 +107,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         longBalance = newLongBalance;
         shortBalance = newShortBalance;
         // Pay the fee
-        IERC20(quoteToken).transferFrom(address(this), feeAddress, totalFeeAmount);
+        IERC20(quoteToken).safeTransferFrom(address(this), feeAddress, totalFeeAmount);
         emit PriceChange(_oldPrice, _newPrice);
     }
 
@@ -113,10 +115,10 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         address from,
         address to,
         uint256 amount
-    ) external override onlyPoolCommitter returns (bool) {
+    ) external override onlyPoolCommitter {
         require(from != address(0), "From address cannot be 0 address");
         require(to != address(0), "To address cannot be 0 address");
-        return IERC20(quoteToken).transferFrom(from, to, amount);
+        IERC20(quoteToken).safeTransferFrom(from, to, amount);
     }
 
     function setNewPoolBalances(uint112 _longBalance, uint112 _shortBalance) external override onlyPoolCommitter {

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -58,10 +58,7 @@ contract PoolCommitter is IPoolCommitter, Ownable {
         // pull in tokens
         if (commitType == CommitType.LongMint || commitType == CommitType.ShortMint) {
             // minting: pull in the quote token from the commiter
-            require(
-                ILeveragedPool(leveragedPool).quoteTokenTransferFrom(msg.sender, address(this), amount),
-                "Transfer failed"
-            );
+            ILeveragedPool(leveragedPool).quoteTokenTransferFrom(msg.sender, address(this), amount);
         } else if (commitType == CommitType.LongBurn) {
             // long burning: pull in long pool tokens from commiter
             ILeveragedPool(leveragedPool).burnTokens(0, amount, msg.sender);
@@ -99,10 +96,7 @@ contract PoolCommitter is IPoolCommitter, Ownable {
         // release tokens
         if (_commit.commitType == CommitType.LongMint || _commit.commitType == CommitType.ShortMint) {
             // minting: return quote tokens to the commit owner
-            require(
-                ILeveragedPool(leveragedPool).quoteTokenTransferFrom(address(this), msg.sender, _commit.amount),
-                "Transfer failed"
-            );
+            ILeveragedPool(leveragedPool).quoteTokenTransferFrom(address(this), msg.sender, _commit.amount);
         } else if (_commit.commitType == CommitType.LongBurn) {
             // long burning: return long pool tokens to commit owner
             ILeveragedPool(leveragedPool).mintTokens(0, _commit.amount, msg.sender);
@@ -185,7 +179,7 @@ contract PoolCommitter is IPoolCommitter, Ownable {
 
             // update long and short balances
             pool.setNewPoolBalances(longBalance - amountOut, shortBalance);
-            require(pool.quoteTokenTransferFrom(address(this), _commit.owner, amountOut), "Transfer failed");
+            pool.quoteTokenTransferFrom(address(this), _commit.owner, amountOut);
         } else if (_commit.commitType == CommitType.ShortMint) {
             uint112 mintAmount = PoolSwapLibrary.getMintAmount(
                 PoolToken(pool.poolTokens()[1]).totalSupply(), // short token total supply
@@ -209,7 +203,7 @@ contract PoolCommitter is IPoolCommitter, Ownable {
 
             // update long and short balances
             pool.setNewPoolBalances(longBalance, shortBalance - amountOut);
-            require(pool.quoteTokenTransferFrom(address(this), _commit.owner, amountOut), "Transfer failed");
+            pool.quoteTokenTransferFrom(address(this), _commit.owner, amountOut);
         }
     }
 

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -91,7 +91,7 @@ interface ILeveragedPool {
         address from,
         address to,
         uint256 amount
-    ) external returns (bool);
+    ) external;
 
     function setNewPoolBalances(uint112 _longBalance, uint112 _shortBalance) external;
 


### PR DESCRIPTION
# Motivation
Rajeev 06 - Safer to use OZ `safeTransferFrom/safeTransfer`

# Changes
- Change to `SafeERC20.sol`
- Also remove unnecessary `require` on ERC20 token transfers. Since OZ ERC20 does not use return value to indicate success.