### PR TITLE
Add Echidna predicates

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -215,4 +215,8 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         require(msg.sender == governance, "msg.sender not governance");
         _;
     }
+
+    function echidna_check_sum_of_balances() public view returns (bool) {
+        return longBalance + shortBalance == IERC20(quoteToken).balanceOf(address(this));
+    }
 }


### PR DESCRIPTION
# Motivation
Due to the simplicity of the Perpetual Pools architecture, the system lends itself rather well to Echidna predicates that operate on the state of the smart contracts themselves. This greatly improves test coverage and confidence in core invariants of the protocol.

# Changes
 - Add an Echidna predicate that checks that `LeveragedPool` is fully backed by settlement tokens
