### PR TITLE
Patch `checkUpkeepSinglePool` tests

### DIFF
--- a/test/PoolKeeper/checkUpkeepSinglePool.ts
+++ b/test/PoolKeeper/checkUpkeepSinglePool.ts
@@ -136,31 +136,43 @@ describe("PoolKeeper - checkUpkeepSinglePool", () => {
     beforeEach(async () => {
         await setupHook()
     })
-    it("should return true if the trigger condition is met", async () => {
-        await forwardTime(5)
 
-        /* induce price increase */
-        let underlyingOracle: TestChainlinkOracle = (await ethers.getContractAt(
-            "TestChainlinkOracle",
-            await oracleWrapper.oracle()
-        )) as TestChainlinkOracle
-        await incrementPrice(underlyingOracle)
+    context("when trigger condition is met", async () => {
+        it("returns true", async () => {
+            await forwardTime(5)
 
-        let poolAddress = await factory.pools(0)
-        expect(await poolKeeper.checkUpkeepSinglePool(poolAddress)).to.eq(true)
+            /* induce price increase */
+            let underlyingOracle: TestChainlinkOracle =
+                (await ethers.getContractAt(
+                    "TestChainlinkOracle",
+                    await oracleWrapper.oracle()
+                )) as TestChainlinkOracle
+            await incrementPrice(underlyingOracle)
+
+            let poolAddress = await factory.pools(0)
+            expect(await poolKeeper.checkUpkeepSinglePool(poolAddress)).to.eq(
+                true
+            )
+        })
     })
-    it("should return false if the trigger condition isn't met", async () => {
-        await forwardTime(5)
 
-        /* induce price increase */
-        let underlyingOracle: TestChainlinkOracle = (await ethers.getContractAt(
-            "TestChainlinkOracle",
-            await oracleWrapper.oracle()
-        )) as TestChainlinkOracle
-        await incrementPrice(underlyingOracle)
+    context("when trigger condition is not met", async () => {
+        it("returns false", async () => {
+            await forwardTime(5)
 
-        let poolAddress = await factory.pools(0)
-        await poolKeeper.performUpkeepSinglePool(poolAddress)
-        expect(await poolKeeper.checkUpkeepSinglePool(poolAddress)).to.eq(false)
+            /* induce price increase */
+            let underlyingOracle: TestChainlinkOracle =
+                (await ethers.getContractAt(
+                    "TestChainlinkOracle",
+                    await oracleWrapper.oracle()
+                )) as TestChainlinkOracle
+            await incrementPrice(underlyingOracle)
+
+            let poolAddress = await factory.pools(0)
+            await poolKeeper.performUpkeepSinglePool(poolAddress)
+            expect(await poolKeeper.checkUpkeepSinglePool(poolAddress)).to.eq(
+                false
+            )
+        })
     })
 })


### PR DESCRIPTION
# Motivation

# Changes
 - Fix test deployment setup
 - Remove redundant test assertion (refer to [associated commit message](https://github.com/mycelium-ethereum/perpetual-pools-contracts/pull/119/commits/c5b3f44294cc4ed0689d1cbe5acc457416c24823) for justification)
 - Remove misplaced test assertion
 - Lift assertions into `context`s
