### PR TITLE
Return instantly if poolUpkeep fails

### DIFF
--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -108,7 +108,7 @@ contract PoolKeeper is IPoolKeeper, Ownable {
         try ILeveragedPool(pool).poolUpkeep(lastExecutionPrice, executionPrice[_pool]) {
             // If poolUpkeep is successful, refund the keeper for their gas costs
             uint256 gasSpent = startGas - gasleft();
-            
+
             // TODO: poll gas price oracle (or BASEFEE)
             // _gasPrice = 10 gwei = 10000000000 wei
             uint256 _gasPrice = 10 gwei;


### PR DESCRIPTION
# Motivation
If `poolUpkeep` fails for any reason, the pool should not refund them gas

# Changes
- Add return to try-catch