### PR TITLE
Fix checkUpkeepMultiplePools tests

### DIFF
--- a/test/PoolKeeper/checkUpkeepMultiplePools.spec.ts
+++ b/test/PoolKeeper/checkUpkeepMultiplePools.spec.ts
@@ -171,7 +171,6 @@ describe("PoolKeeper - checkUpkeepMultiplePools", () => {
         ]
         await forwardTime(5)
         await incrementPrice(underlyingOracle)
-        await poolKeeper.performUpkeepMultiplePools(poolAddresses)
         expect(await poolKeeper.checkUpkeepMultiplePools(poolAddresses)).to.eq(
             false
         )


### PR DESCRIPTION
# Motivation
Due to refactors, `checkUpkeepMultiplePools`'s tests were broke. This PR fixes them.

# Changes
- Patch & add checkUpkeepMultiplePools tests