### PR TITLE
Update events

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -95,6 +95,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         executePriceChange(_oldPrice, _newPrice);
         // execute pending commitments to enter and exit the pool
         IPoolCommitter(poolCommitter).executeAllCommitments();
+        emit CompletedUpkeep(_oldPrice, _newPrice);
     }
 
     /**
@@ -157,8 +158,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
     /**
      * @notice Execute the price change once the interval period ticks over, updating the long & short
      *         balances based on the change of the feed (upwards or downwards) and paying fees
-     * @dev Can only be called by poolUpkeep; emits PriceChangeError if execution does not take place,
-     *      and PriceChange if it does
+     * @dev Can only be called by poolUpkeep; emits PriceChangeError if execution does not take place
      * @param _oldPrice Old price from the oracle
      * @param _newPrice New price from the oracle
      */
@@ -184,7 +184,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
             shortBalance = newShortBalance;
             // Pay the fee
             IERC20(quoteToken).safeTransfer(feeAddress, totalFeeAmount);
-            emit PriceChange(_oldPrice, _newPrice);
         }
     }
 

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -32,11 +32,11 @@ interface ILeveragedPool {
     event PoolInitialized(address indexed longToken, address indexed shortToken, address quoteToken, string poolName);
 
     /**
-     * @notice Creates a notification when the pool's price execution succeeds
+     * @notice Creates a notification when the pool's upkeep succeeds
      * @param startPrice Price prior to price change execution
      * @param endPrice Price during price change execution
      */
-    event PriceChange(int256 indexed startPrice, int256 indexed endPrice);
+    event CompletedUpkeep(int256 indexed startPrice, int256 indexed endPrice);
 
     /**
      * @notice Creates a notification when the pool's price execution fails

--- a/documentation/contract-reference.md
+++ b/documentation/contract-reference.md
@@ -253,12 +253,11 @@ event ExecuteCommit(uint128 commitID);
 ```  
 Emitted when a commit is executed. Commit execution is the transfer of funds from the pool's shadow balance into the live balances. 
 
-#### PriceChange
+#### Upkeep
 ```
-event PriceChange(
+event CompletedUpkeep(
     int256 indexed startPrice,
     int256 indexed endPrice,
-    uint256 indexed transferAmount
   );
 ```  
 Emitted when a price change execution occurs.


### PR DESCRIPTION
# Motivation
Get a single event so I can update pool state after upkeep

# Changes
- rename PriceChange event to CompletedUpkeep
- move even outside of execute priceChange and into the bottom of upkeep
- update contract docs