### PR TITLE
Import ERC20 instead of copy-pasting code

### DIFF
--- a/contracts/vendors/ERC20_Cloneable.sol
+++ b/contracts/vendors/ERC20_Cloneable.sol
@@ -47,7 +47,7 @@ contract ERC20_Cloneable is Context, ERC20, Initializable {
      * construction.
      */
     constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {
-        _decimals = 8;
+        _decimals = 18;
     }
 
     function initialize(


### PR DESCRIPTION
# Motivation

ERC20_Cloneable just copy and pasted the ERC20 function implementations, allowing for the contract to become outdated and not do necessary checks like "is this guy trying to burn more than he owns?"

# Changes
- Now just import the ERC20.sol file directly, so we do not have to worry about the above sorts of problems


**REVIEWERS:** Please confirm my opinion that the copy-pasted functions didn't have extra things added. I am sure they didn't (all tests still pass + manual review), but just make sure please