### PR TITLE
Change token naming

### DIFF
--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -91,12 +91,16 @@ contract PoolFactory is IPoolFactory, Ownable {
 
         address shortToken = deployPairToken(
             _pool,
-            string(abi.encodePacked(uint2str(deploymentParameters.leverageAmount), "S-", deploymentParameters.poolName)),
+            string(
+                abi.encodePacked(uint2str(deploymentParameters.leverageAmount), "S-", deploymentParameters.poolName)
+            ),
             string(abi.encodePacked(uint2str(deploymentParameters.leverageAmount), "S-", deploymentParameters.poolName))
         );
         address longToken = deployPairToken(
             _pool,
-            string(abi.encodePacked(uint2str(deploymentParameters.leverageAmount), "L-", deploymentParameters.poolName)),
+            string(
+                abi.encodePacked(uint2str(deploymentParameters.leverageAmount), "L-", deploymentParameters.poolName)
+            ),
             string(abi.encodePacked(uint2str(deploymentParameters.leverageAmount), "L-", deploymentParameters.poolName))
         );
         ILeveragedPool.Initialization memory initialization = ILeveragedPool.Initialization(
@@ -176,21 +180,21 @@ contract PoolFactory is IPoolFactory, Ownable {
         return owner();
     }
 
-    function uint2str(uint _i) internal pure returns (string memory _uintAsString) {
+    function uint2str(uint256 _i) internal pure returns (string memory _uintAsString) {
         if (_i == 0) {
             return "0";
         }
-        uint j = _i;
-        uint len;
+        uint256 j = _i;
+        uint256 len;
         while (j != 0) {
             len++;
             j /= 10;
         }
         bytes memory bstr = new bytes(len);
-        uint k = len;
+        uint256 k = len;
         while (_i != 0) {
-            k = k-1;
-            uint8 temp = (48 + uint8(_i - _i / 10 * 10));
+            k = k - 1;
+            uint8 temp = (48 + uint8(_i - (_i / 10) * 10));
             bytes1 b1 = bytes1(temp);
             bstr[k] = b1;
             _i /= 10;

--- a/test/LeveragedPool/initialize.spec.ts
+++ b/test/LeveragedPool/initialize.spec.ts
@@ -128,10 +128,18 @@ describe("LeveragedPool - initialize", () => {
 
             expect(longAddress).to.not.eq(ethers.constants.AddressZero)
             expect(shortAddress).to.not.eq(ethers.constants.AddressZero)
-            expect(await longToken.symbol()).to.eq(leverage.toString().concat("L-".concat(POOL_CODE)))
-            expect(await shortToken.symbol()).to.eq(leverage.toString().concat("S-".concat(POOL_CODE)))
-            expect(await longToken.name()).to.eq(leverage.toString().concat("L-".concat(POOL_CODE)))
-            expect(await shortToken.name()).to.eq(leverage.toString().concat("S-".concat(POOL_CODE)))
+            expect(await longToken.symbol()).to.eq(
+                leverage.toString().concat("L-".concat(POOL_CODE))
+            )
+            expect(await shortToken.symbol()).to.eq(
+                leverage.toString().concat("S-".concat(POOL_CODE))
+            )
+            expect(await longToken.name()).to.eq(
+                leverage.toString().concat("L-".concat(POOL_CODE))
+            )
+            expect(await shortToken.name()).to.eq(
+                leverage.toString().concat("S-".concat(POOL_CODE))
+            )
         })
 
         it("should emit an event containing the details of the new pool", async () => {


### PR DESCRIPTION
# Motivation
Token naming and symbol could fall outside of the 12 character limit enforced client side via metamask. Leverage was also not being included in the the token name or symbol.

# Changes
- adds leverage to token name and symbol
- uses shorthand L or S for long and short.