### PR TITLE
Unnecessary multiplication

### DIFF
--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -170,7 +170,7 @@ contract PoolKeeper is IPoolKeeper, Ownable {
 
         // tip percent in wad units
         bytes16 _tipPercent = ABDKMathQuad.fromUInt(keeperTip(_savedPreviousUpdatedTimestamp, _poolInterval));
-        
+
         // amount of settlement tokens to give to the keeper
         _tipPercent = ABDKMathQuad.div(_tipPercent, ABDKMathQuad.fromUInt(100));
         int256 wadRewardValue = ABDKMathQuad.toInt(

--- a/test/PoolKeeper/performUpkeep/basicFunctions.spec.ts
+++ b/test/PoolKeeper/performUpkeep/basicFunctions.spec.ts
@@ -170,9 +170,7 @@ describe("PoolKeeper - performUpkeep: basic functionality", () => {
             newLastExecutionTime = await pool.lastPriceTimestamp()
         })
         it("should clear the old round data", async () => {
-            const price = ethers.utils.parseEther(
-                (await derivativeOracleWrapper.getPrice()).toString()
-            )
+            const price = await derivativeOracleWrapper.getPrice()
             expect(newLastExecutionTime.gt(oldLastExecutionTime)).to.equal(true)
             expect(newExecutionPrice).to.be.lt(oldExecutionPrice)
             expect(newExecutionPrice).to.equal(price)


### PR DESCRIPTION
 # Motivation
Fixes TCR-06 by removing unnecessary multiplication from the `PoolKeeper` contract.

# Changes
- removes extra multiplications from `keeperReward()` and `performUpkeepSinglePool()`
- patches tests