### PR TITLE
Add address and roundID to upkeep event

### DIFF
--- a/contracts/implementation/ChainlinkOracleWrapper.sol
+++ b/contracts/implementation/ChainlinkOracleWrapper.sol
@@ -43,10 +43,12 @@ contract ChainlinkOracleWrapper is IOracleWrapper, Ownable {
 
     /**
      * @return _price The latest round data price
-     * @return _roundID The latest round ID
+     * @return _data The metadata. Implementations can choose what data to return here. This implementation returns the roundID
      */
-    function getPriceAndRoundID() external view override returns (int256 _price, uint80 _roundID) {
-        (_price, _roundID) = _latestRoundData();
+    function getPriceAndMetadata() external view override returns (int256 _price, bytes memory _data) {
+        (int256 price, uint80 roundID) = _latestRoundData();
+        _data = abi.encodePacked(roundID);
+        return (price, _data);
     }
 
     /**

--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -319,7 +319,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
 
     /**
      * @return _latestPrice The oracle price
-     * @return _roundID The latest roundID
+     * @return _data The oracleWrapper's metadata. Implementations can choose what data to return here
      * @return _lastPriceTimestamp The timestamp of the last upkeep
      * @return _updateInterval The update frequency for this pool
      * @dev To save gas so PoolKeeper does not have to make three external calls
@@ -330,13 +330,13 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         override
         returns (
             int256 _latestPrice,
-            uint80 _roundID,
+            bytes memory _data,
             uint256 _lastPriceTimestamp,
             uint256 _updateInterval
         )
     {
-        (_latestPrice, _roundID) = IOracleWrapper(oracleWrapper).getPriceAndRoundID();
-        return (_latestPrice, _roundID, lastPriceTimestamp, updateInterval);
+        (_latestPrice, _data) = IOracleWrapper(oracleWrapper).getPriceAndMetadata();
+        return (_latestPrice, _data, lastPriceTimestamp, updateInterval);
     }
 
     /**

--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -95,7 +95,7 @@ contract PoolKeeper is IPoolKeeper, Ownable {
             return;
         }
         ILeveragedPool pool = ILeveragedPool(_pool);
-        (int256 latestPrice, uint80 roundID, uint256 savedPreviousUpdatedTimestamp, uint256 updateInterval) = pool
+        (int256 latestPrice, bytes memory data, uint256 savedPreviousUpdatedTimestamp, uint256 updateInterval) = pool
             .getUpkeepInformation();
 
         // Start a new round
@@ -110,8 +110,7 @@ contract PoolKeeper is IPoolKeeper, Ownable {
             uint256 gasSpent = startGas - gasleft();
 
             payKeeper(_pool, gasPrice, gasSpent, savedPreviousUpdatedTimestamp, updateInterval);
-            emit UpkeepSuccessful(_pool, lastExecutionPrice, latestPrice);
-            emit UpkeepRoundID(_pool, roundID);
+            emit UpkeepSuccessful(_pool, data, lastExecutionPrice, latestPrice);
         } catch Error(string memory reason) {
             // If poolUpkeep fails for any other reason, emit event
             emit PoolUpkeepError(_pool, reason);

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -120,7 +120,7 @@ interface ILeveragedPool {
 
     /**
      * @return _latestPrice The oracle price
-     * @return _roundID The latest roundID
+     * @return _data The oracleWrapper's metadata. Implementations can choose what data to return here
      * @return _lastPriceTimestamp The timestamp of the last upkeep
      * @return _updateInterval The update frequency for this pool
      * @dev To save gas so PoolKeeper does not have to make three external calls
@@ -130,7 +130,7 @@ interface ILeveragedPool {
         view
         returns (
             int256 _latestPrice,
-            uint80 _roundID,
+            bytes memory _data,
             uint256 _lastPriceTimestamp,
             uint256 _updateInterval
         );

--- a/contracts/interfaces/IOracleWrapper.sol
+++ b/contracts/interfaces/IOracleWrapper.sol
@@ -21,9 +21,9 @@ interface IOracleWrapper {
 
     /**
      * @return _price The latest round data price
-     * @return _roundID The latest round ID
+     * @return _data The metadata. Implementations can choose what data to return here
      */
-    function getPriceAndRoundID() external view returns (int256 _price, uint80 _roundID);
+    function getPriceAndMetadata() external view returns (int256 _price, bytes memory _data);
 
     /**
      * @notice Converts from a WAD to normal value

--- a/contracts/interfaces/IPoolKeeper.sol
+++ b/contracts/interfaces/IPoolKeeper.sol
@@ -14,17 +14,11 @@ interface IPoolKeeper {
     /**
      * @notice Creates a notification when a call to LeveragedPool:poolUpkeep is successful
      * @param pool The pool address being upkept
-     * @param roundID The roundID for the price data
-     */
-    event UpkeepRoundID(address indexed pool, uint80 indexed roundID);
-
-    /**
-     * @notice Creates a notification when a call to LeveragedPool:poolUpkeep is successful
-     * @param pool The pool address being upkept
+     * @param data Extra data about the price fetch. This could be roundID in the case of Chainlink Oracles
      * @param startPrice The previous price of the pool
      * @param endPrice The new price of the pool
      */
-    event UpkeepSuccessful(address indexed pool, int256 indexed startPrice, int256 indexed endPrice);
+    event UpkeepSuccessful(address indexed pool, bytes data, int256 indexed startPrice, int256 indexed endPrice);
 
     /**
      * @notice Creates a notification when a keeper is paid for doing upkeep for a pool


### PR DESCRIPTION
# Motivation
It would be useful if `PoolKeeper::UpkeepSuccessful` actually specified the pool that had a successful upkeep.

It would also be helpful for data fetching if the event emitted `roundID` as well.
- Unfortunately, that would put it over the 4 `indexed` parameters. So you

I also noticed an unnecessary cast to `ILeveragedPool` when it had already done that.

# Changes
- Add `address pool` to `PoolKeeper::UpkeepSuccessful`
- Add `event UpkeepRoundID(address indexed pool, uint80 indexed roundID);`
    - This allows for 4 `indexed` event params in total. Since the usual cap is 3
- Remove an unnecessary cast to `ILeveragedPool`

**ChainlinkOracleWrapper**
- Add an internal function `_latestRoundData`
    - This is called by `getPrice`, and the new `getPriceAndRoundID`