### PR TITLE
Arbitrum bridged administrator

### DIFF
--- a/contracts/implementation/Administrator.sol
+++ b/contracts/implementation/Administrator.sol
@@ -57,10 +57,22 @@ contract Administrator is Ownable, IAdministrator {
     }
 
     function unpause() external payable override onlyOwner returns (uint256) {
-        /* TODO: unpause */
+        /* construct desired call data */
+        bytes memory data = abi.encodeWithSelector(LeveragedPool.unpause.selector);
+
+        /* perform the call to L2 */
+        uint256 ticket_id = callL2(data);
+
+        return ticket_id;
     }
 
     function withdraw() external payable override onlyOwner returns (uint256) {
-        /* TODO: withdraw */
+        /* construct desired call data */
+        bytes memory data = abi.encodeWithSelector(LeveragedPool.withdrawQuote.selector);
+
+        /* perform the call to L2 */
+        uint256 ticket_id = callL2(data);
+
+        return ticket_id;
     }
 }

--- a/contracts/implementation/Administrator.sol
+++ b/contracts/implementation/Administrator.sol
@@ -17,6 +17,8 @@ contract Administrator is Ownable, IAdministrator {
     }
 
     function callL2(address target, bytes memory payload) public payable onlyOwner returns (uint256) {
+        require(target != address(0), "ADMIN: Target address cannot be null");
+
         uint256 max_submission_cost = 1;
         uint256 max_gas = 1;
         uint256 gas_price_bid = 1;
@@ -40,32 +42,38 @@ contract Administrator is Ownable, IAdministrator {
      * @notice Pauses the pool on L2
      * @dev Submits a message to the L2 inbox
      */
-    function pause() external payable override onlyOwner returns (uint256) {
+    function pause(address pool) external payable override onlyOwner returns (uint256) {
+        require(pool != address(0), "ADMIN: Pool address cannot be null");
+
         /* construct desired call data */
         bytes memory data = abi.encodeWithSelector(LeveragedPool.pause.selector);
 
         /* perform the call to L2 */
-        uint256 ticket_id = callL2(data);
+        uint256 ticket_id = callL2(pool, data);
 
         return ticket_id;
     }
 
-    function unpause() external payable override onlyOwner returns (uint256) {
+    function unpause(address pool) external payable override onlyOwner returns (uint256) {
+        require(pool != address(0), "ADMIN: Pool address cannot be null");
+
         /* construct desired call data */
         bytes memory data = abi.encodeWithSelector(LeveragedPool.unpause.selector);
 
         /* perform the call to L2 */
-        uint256 ticket_id = callL2(data);
+        uint256 ticket_id = callL2(pool, data);
 
         return ticket_id;
     }
 
-    function withdraw() external payable override onlyOwner returns (uint256) {
+    function withdraw(address pool) external payable override onlyOwner returns (uint256) {
+        require(pool != address(0), "ADMIN: Pool address cannot be null");
+
         /* construct desired call data */
         bytes memory data = abi.encodeWithSelector(LeveragedPool.withdrawQuote.selector);
 
         /* perform the call to L2 */
-        uint256 ticket_id = callL2(data);
+        uint256 ticket_id = callL2(pool, data);
 
         return ticket_id;
     }

--- a/contracts/implementation/Administrator.sol
+++ b/contracts/implementation/Administrator.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.7;
+
+contract Administrator is Ownable, IAdminstrator {
+    address target;
+
+    constructor(address _target) {
+        require(_target != address(0), "Target address cannot be null");
+        target = _target;
+    }
+
+    function pause() external override onlyOwner {
+        /* TODO: pause */
+    }
+
+    function unpause() external override onlyOwner {
+        /* TODO: unpause */
+    }
+
+    function withdraw() external override onlyOwner {
+        /* TODO: withdraw */
+    }
+}

--- a/contracts/implementation/Administrator.sol
+++ b/contracts/implementation/Administrator.sol
@@ -9,20 +9,14 @@ import "../interfaces/IAdministrator.sol";
 import "../implementation/LeveragedPool.sol";
 
 contract Administrator is Ownable, IAdministrator {
-    address public target;
     IInbox public inbox;
 
-    constructor(address _target) {
-        require(_target != address(0), "Target address cannot be null");
-        target = _target;
+    constructor(address _inbox) {
+        require(_inbox != address(0), "ADMIN: Inbox address cannot be null");
+        inbox = IInbox(_inbox);
     }
 
-    function setTarget(address _target) external onlyOwner {
-        require(_target != address(0), "Target address cannot be null");
-        target = _target;
-    }
-
-    function callL2(bytes memory payload) public payable onlyOwner returns (uint256) {
+    function callL2(address target, bytes memory payload) public payable onlyOwner returns (uint256) {
         uint256 max_submission_cost = 1;
         uint256 max_gas = 1;
         uint256 gas_price_bid = 1;

--- a/contracts/implementation/Administrator.sol
+++ b/contracts/implementation/Administrator.sol
@@ -1,23 +1,66 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.7;
 
-contract Administrator is Ownable, IAdminstrator {
-    address target;
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "arbitrum-tutorials/packages/arb-shared-dependencies/contracts/Inbox.sol";
+import "arbitrum-tutorials/packages/arb-shared-dependencies/contracts/Outbox.sol";
+
+import "../interfaces/IAdministrator.sol";
+import "../implementation/LeveragedPool.sol";
+
+contract Administrator is Ownable, IAdministrator {
+    address public target;
+    IInbox public inbox;
 
     constructor(address _target) {
         require(_target != address(0), "Target address cannot be null");
         target = _target;
     }
 
-    function pause() external override onlyOwner {
-        /* TODO: pause */
+    function setTarget(address _target) external onlyOwner {
+        require(_target != address(0), "Target address cannot be null");
+        target = _target;
     }
 
-    function unpause() external override onlyOwner {
+    function callL2(bytes memory payload) public payable onlyOwner returns (uint256) {
+        uint256 max_submission_cost = 1;
+        uint256 max_gas = 1;
+        uint256 gas_price_bid = 1;
+
+        /* create retryable ticket in the L2 inbox */
+        uint256 ticket_id = inbox.createRetryableTicket{value: msg.value}(
+            target,
+            0,
+            max_submission_cost,
+            msg.sender,
+            msg.sender,
+            max_gas,
+            gas_price_bid,
+            payload
+        );
+
+        return ticket_id;
+    }
+
+    /**
+     * @notice Pauses the pool on L2
+     * @dev Submits a message to the L2 inbox
+     */
+    function pause() external payable override onlyOwner returns (uint256) {
+        /* construct desired call data */
+        bytes memory data = abi.encodeWithSelector(LeveragedPool.pause.selector);
+
+        /* perform the call to L2 */
+        uint256 ticket_id = callL2(data);
+
+        return ticket_id;
+    }
+
+    function unpause() external payable override onlyOwner returns (uint256) {
         /* TODO: unpause */
     }
 
-    function withdraw() external override onlyOwner {
+    function withdraw() external payable override onlyOwner returns (uint256) {
         /* TODO: withdraw */
     }
 }

--- a/contracts/interfaces/IAdministrator.sol
+++ b/contracts/interfaces/IAdministrator.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.7;
+
+interface IAdministrator {
+    event Paused();
+    event Unpaused();
+    event Withdrew();
+
+    function pause() external;
+    function unpause() external;
+    function withdraw() external;
+}

--- a/contracts/interfaces/IAdministrator.sol
+++ b/contracts/interfaces/IAdministrator.sol
@@ -6,9 +6,9 @@ interface IAdministrator {
     event Unpaused();
     event Withdrew();
 
-    function pause() external payable returns (uint256);
+    function pause(address pool) external payable returns (uint256);
 
-    function unpause() external payable returns (uint256);
+    function unpause(address pool) external payable returns (uint256);
 
-    function withdraw() external payable returns (uint256);
+    function withdraw(address pool) external payable returns (uint256);
 }

--- a/contracts/interfaces/IAdministrator.sol
+++ b/contracts/interfaces/IAdministrator.sol
@@ -6,7 +6,9 @@ interface IAdministrator {
     event Unpaused();
     event Withdrew();
 
-    function pause() external;
-    function unpause() external;
-    function withdraw() external;
+    function pause() external payable returns (uint256);
+
+    function unpause() external payable returns (uint256);
+
+    function withdraw() external payable returns (uint256);
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "@chainlink/contracts": "^0.2.1",
         "@openzeppelin/contracts": "^4.2.0",
         "abdk-libraries-solidity": "^3.0.0",
+        "arbitrum-tutorials": "https://github.com/OffchainLabs/arbitrum-tutorials",
         "hardhat": "^2.6.0",
         "hardhat-log-remover": "^2.0.2",
         "solidity-coverage": "^0.7.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,6 +1359,10 @@ anymatch@~3.1.1, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+"arbitrum-tutorials@https://github.com/OffchainLabs/arbitrum-tutorials":
+  version "1.0.0"
+  resolved "https://github.com/OffchainLabs/arbitrum-tutorials#f11a1e0493fb706b35d7f9d78ee8610875f917ae"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"


### PR DESCRIPTION
# Motivation
Currently, Arbitrum does not support Gnosis Safe multisig SC-based wallets. One possible solution to this is to have a contract deployed onto the Ethereum mainnet and have it perform message passing back and forth with the contracts on Arbitrum's L2 mainnet.

# Changes
 - Add `IAdministrator` interface
 - Add `Administrator` contract implementing the `IAdministrator` interface
