### PR TITLE
Cap keeper tip

### DIFF
--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -223,7 +223,14 @@ contract PoolKeeper is IPoolKeeper, Ownable {
         /* the number of blocks that have elapsed since the given pool's updateInterval passed */
         uint256 elapsedBlocksNumerator = (block.timestamp - (_savedPreviousUpdatedTimestamp + _poolInterval));
 
-        return BASE_TIP + (TIP_DELTA_PER_BLOCK * elapsedBlocksNumerator) / BLOCK_TIME;
+        uint256 keeperTip = BASE_TIP + (TIP_DELTA_PER_BLOCK * elapsedBlocksNumerator) / BLOCK_TIME;
+
+        // In case of network outages or otherwise, we want to cap the tip so that the keeper cost isn't unbounded
+        if (keeperTip > 100) {
+            return 100;
+        } else {
+            return keeperTip;
+        }
     }
 
     function setFactory(address _factory) external override onlyOwner {


### PR DESCRIPTION
# Motivation
In case the network that the perpetual pools contracts suffer an outage and are unavailable for hours, we don't want the keeper tip to be unbounded

# Changes
- Cap keeper tip at 100% such that the cost of the keeper isn't prohibitive