### PR TITLE
Enforce decimal precision of pool tokens based on settlement token's precision

### DIFF
--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -29,6 +29,8 @@ contract PoolFactory is IPoolFactory, Ownable {
     // Default fee; Fee value as a decimal multiplied by 10^18. For example, 0.5% is represented as 0.5 * 10^18
     uint256 public fee;
 
+    uint8 constant DEFAULT_NUM_DECIMALS = 18;
+
     /**
      * @notice Format: Pool counter => pool address
      */
@@ -43,7 +45,7 @@ contract PoolFactory is IPoolFactory, Ownable {
     // #### Functions
     constructor(address _feeReceiver) {
         // Deploy base contracts
-        pairTokenBase = new PoolToken();
+        pairTokenBase = new PoolToken(DEFAULT_NUM_DECIMALS);
         pairTokenBaseAddress = address(pairTokenBase);
         poolBase = new LeveragedPool();
         poolBaseAddress = address(poolBase);

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -29,6 +29,8 @@ contract PoolFactory is IPoolFactory, Ownable {
     // Default fee; Fee value as a decimal multiplied by 10^18. For example, 0.5% is represented as 0.5 * 10^18
     uint256 public fee;
 
+    // This is required because we must pass along *some* value for decimal
+    // precision to the base pool tokens as we use the Cloneable pattern
     uint8 constant DEFAULT_NUM_DECIMALS = 18;
 
     /**
@@ -137,6 +139,7 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @notice Deploy a contract for pool tokens
      * @param name Name of the token
      * @param symbol Symbol of the token
+     * @param decimals Number of decimal places to be supported
      * @return Address of the pool token
      */
     function deployPairToken(

--- a/contracts/implementation/PoolToken.sol
+++ b/contracts/implementation/PoolToken.sol
@@ -11,7 +11,7 @@ contract PoolToken is ERC20_Cloneable, IPoolToken {
 
     // #### Functions
 
-    constructor() ERC20_Cloneable("BASE_TOKEN", "BASE") {}
+    constructor(uint8 _decimals) ERC20_Cloneable("BASE_TOKEN", "BASE", _decimals) {}
 
     /**
      * @notice Mints pool tokens

--- a/contracts/vendors/ERC20_Cloneable.sol
+++ b/contracts/vendors/ERC20_Cloneable.sol
@@ -57,12 +57,13 @@ contract ERC20_Cloneable is Context, ERC20, Initializable {
     function initialize(
         address _pool,
         string memory name_,
-        string memory symbol_
+        string memory symbol_,
+        uint8 decimals_
     ) external initializer {
         owner = _pool;
         _name = name_;
         _symbol = symbol_;
-        _decimals = 18;
+        _decimals = decimals_;
     }
 
     function decimals() public view virtual override returns (uint8) {

--- a/contracts/vendors/ERC20_Cloneable.sol
+++ b/contracts/vendors/ERC20_Cloneable.sol
@@ -46,8 +46,12 @@ contract ERC20_Cloneable is Context, ERC20, Initializable {
      * All three of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {
-        _decimals = 18;
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) ERC20(name_, symbol_) {
+        _decimals = decimals_;
     }
 
     function initialize(

--- a/test/LeveragedPool/initialize.spec.ts
+++ b/test/LeveragedPool/initialize.spec.ts
@@ -143,6 +143,9 @@ describe("LeveragedPool - initialize", () => {
             expect(await shortToken.name()).to.eq(
                 leverage.toString().concat("S-".concat(POOL_CODE))
             )
+            // check decimals
+            expect(await shortToken.decimals()).to.eq(18)
+            expect(await longToken.decimals()).to.eq(18)
         })
 
         it("should emit an event containing the details of the new pool", async () => {


### PR DESCRIPTION
# Motivation
Currently, the pool tokens are deployed with 18 decimal places, regardless of whatever precision the settlement token supports. While this preserves both the pool ratio and all internal accounting, external tooling (e.g. block explorers, wallets, etc.) misrepresent quantities of pool tokens.

# Changes
 - Modify `ERC20_Cloneable` to accept an arbitrary value for decimal precision rather than hardcoding to 18 decimal places
 - Add decimal precision parameter to `PoolToken` in order to pass it along to the aforementioned `ERC20_Cloneable` parameter
 - Add default decimal precision value to the `PoolFactory` due to Cloneable pattern

# Acceptance Criteria
 - [x] `PoolToken` constructor has a `decimals` parameter
 - [x] `ERC20_Cloneable` constructor has a `decimals` parameter
 - [x] `PoolToken.initialize` has a `decimals` parameter
 - [x] `PoolFactory.deployPairToken` has a `decimals` parameter
 - [x] All tests pass with 6 decimal places