### PR TITLE
Remove try catch in performUpkeepSinglePool

### DIFF
--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -103,16 +103,12 @@ contract PoolKeeper is IPoolKeeper, Ownable {
 
         // This allows us to still batch multiple calls to executePriceChange, even if some are invalid
         // Without reverting the entire transaction
-        try pool.poolUpkeep(lastExecutionPrice, latestPrice) {
-            // If poolUpkeep is successful, refund the keeper for their gas costs
-            uint256 gasSpent = startGas - gasleft();
+        pool.poolUpkeep(lastExecutionPrice, latestPrice);
+        // If poolUpkeep is successful, refund the keeper for their gas costs
+        uint256 gasSpent = startGas - gasleft();
 
-            payKeeper(_pool, gasPrice, gasSpent, savedPreviousUpdatedTimestamp, updateInterval);
-            emit UpkeepSuccessful(_pool, data, lastExecutionPrice, latestPrice);
-        } catch Error(string memory reason) {
-            // If poolUpkeep fails for any other reason, emit event
-            emit PoolUpkeepError(_pool, reason);
-        }
+        payKeeper(_pool, gasPrice, gasSpent, savedPreviousUpdatedTimestamp, updateInterval);
+        emit UpkeepSuccessful(_pool, data, lastExecutionPrice, latestPrice);
     }
 
     /**

--- a/contracts/interfaces/IPoolKeeper.sol
+++ b/contracts/interfaces/IPoolKeeper.sol
@@ -36,13 +36,6 @@ interface IPoolKeeper {
      */
     event KeeperPaymentError(address indexed _pool, address indexed keeper, uint256 expectedReward);
 
-    /**
-     * @notice Creates a notification of a failed pool update
-     * @param pool The pool that failed to update
-     * @param reason The reason for the error
-     */
-    event PoolUpkeepError(address indexed pool, string reason);
-
     // #### Functions
     function newPool(address _poolAddress) external;
 


### PR DESCRIPTION
# Motivation
If a pool's upkeep fails, the price updates and does not get reverted. It would also make more sense to revert on a failed upkeep from a general Ethereum common patterns point of view.

# Changes
- Remove the `try catch` statement that wraps `pool.poolUpkeep` in the `PoolKeeper::performUpkeepSinglePool` function.