### PR TITLE
Documentation comments

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -319,7 +319,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
     }
 
     /**
-     * @notice Indicates whether the price was last updated more than `updateInterval` seconds ago 
+     * @notice Indicates whether the price was last updated more than `updateInterval` seconds ago
      * @return Whether the price was last updated more than `updateInterval` seconds ago
      * @dev Unchecked
      */

--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -90,7 +90,13 @@ contract LeveragedPool is ILeveragedPool, Initializable {
 
     /**
      * @notice Execute a price change
+     * @param _oldPrice Previous price of the underlying asset
+     * @param _newPrice New price of the underlying asset
+     * @dev Throws if at least one update interval has not elapsed since last price update
      * @dev This is the entry point to upkeep a market
+     * @dev Only callable by the associated `PoolKeeper` contract
+     * @dev Only callable if the market is *not* paused
+     *
      */
     function poolUpkeep(int256 _oldPrice, int256 _newPrice) external override onlyKeeper onlyUnpaused {
         require(intervalPassed(), "Update interval hasn't passed");
@@ -106,6 +112,9 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param amount Amount to pay the pool keeper
      * @return Whether the keeper is going to be paid; false if the amount exceeds the balances of the
      *         long and short pool, and true if the keeper can successfully be paid out
+     * @dev Only callable by the associated `PoolKeeper` contract
+     * @dev Only callable when the market is *not* paused
+     *
      */
     function payKeeperFromBalances(address to, uint256 amount)
         external
@@ -141,6 +150,9 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @notice Transfer settlement tokens from pool to user
      * @param to Address of account to transfer to
      * @param amount Amount of quote tokens being transferred
+     * @dev Only callable by the associated `PoolCommitter` contract
+     * @dev Only callable when the market is *not* paused
+     *
      */
     function quoteTokenTransfer(address to, uint256 amount) external override onlyPoolCommitter onlyUnpaused {
         IERC20(quoteToken).safeTransfer(to, amount);
@@ -151,6 +163,9 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param to Address of account to transfer to
      * @param isLongToken True if transferring long pool token
      * @param amount Amount of quote tokens being transferred
+     * @dev Only callable by the associated `PoolCommitter` contract
+     * @dev Only callable when the market is *not* paused
+     *
      */
     function poolTokenTransfer(
         bool isLongToken,
@@ -169,6 +184,9 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param from The account that's transferring quote tokens
      * @param to Address of account to transfer to
      * @param amount Amount of quote tokens being transferred
+     * @dev Only callable by the associated `PoolCommitter` contract
+     * @dev Only callable when the market is *not* paused
+     *
      */
     function quoteTokenTransferFrom(
         address from,
@@ -181,9 +199,13 @@ contract LeveragedPool is ILeveragedPool, Initializable {
     /**
      * @notice Execute the price change once the interval period ticks over, updating the long & short
      *         balances based on the change of the feed (upwards or downwards) and paying fees
-     * @dev Can only be called by poolUpkeep; emits PriceChangeError if execution does not take place
      * @param _oldPrice Old price from the oracle
      * @param _newPrice New price from the oracle
+     * @dev Can only be called by poolUpkeep
+     * @dev Only callable when the market is *not* paused
+     * @dev Emits `PoolRebalance` if execution succeeds
+     * @dev Emits `PriceChangeError` if execution does not take place
+     *
      */
     function executePriceChange(int256 _oldPrice, int256 _newPrice) internal onlyUnpaused {
         // prevent a division by 0 in computing the price change
@@ -222,6 +244,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @notice Execute the fee transfer transactions. Transfers fees to primary fee address (DAO) and secondary (pool deployer).
      *         If the DAO is the fee deployer, secondary fee address should be address(0) and all fees go to DAO.
      * @param totalFeeAmount total amount of fees paid
+     *
      */
     function feeTransfer(uint256 totalFeeAmount) internal {
         if (secondaryFeeAddress == address(0)) {
@@ -236,9 +259,11 @@ contract LeveragedPool is ILeveragedPool, Initializable {
 
     /**
      * @notice Sets the long and short balances of the pools
-     * @dev Can only be called by & used by the pool committer
      * @param _longBalance New balance of the long pool
-     * @param _shortBalance New balancee of the short pool
+     * @param _shortBalance New balance of the short pool
+     * @dev Only callable by the associated `PoolCommitter` contract
+     * @dev Only callable when the market is *not* paused
+     *
      */
     function setNewPoolBalances(uint256 _longBalance, uint256 _shortBalance)
         external
@@ -252,10 +277,12 @@ contract LeveragedPool is ILeveragedPool, Initializable {
 
     /**
      * @notice Mint tokens to a user
-     * @dev Can only be called by & used by the pool committer
      * @param isLongToken True if minting short token
      * @param amount Amount of tokens to mint
      * @param minter Address of user/minter
+     * @dev Only callable by the associated `PoolCommitter` contract
+     * @dev Only callable when the market is *not* paused
+     *
      */
     function mintTokens(
         bool isLongToken,
@@ -275,6 +302,9 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param isLongToken True if burning short token
      * @param amount Amount of tokens to burn
      * @param burner Address of user/burner
+     * @dev Only callable by the associated `PoolCommitter` contract
+     * @dev Only callable when the market is *not* paused
+     *
      */
     function burnTokens(
         bool isLongToken,
@@ -289,7 +319,9 @@ contract LeveragedPool is ILeveragedPool, Initializable {
     }
 
     /**
-     * @return true if the price was last updated more than updateInterval seconds ago
+     * @notice Indicates whether the price was last updated more than `updateInterval` seconds ago 
+     * @return Whether the price was last updated more than `updateInterval` seconds ago
+     * @dev Unchecked
      */
     function intervalPassed() public view override returns (bool) {
         unchecked {
@@ -300,6 +332,9 @@ contract LeveragedPool is ILeveragedPool, Initializable {
     /**
      * @notice Updates the fee address of the pool
      * @param account New address of the fee address/receiver
+     * @dev Only callable by governance
+     * @dev Only callable when the market is *not* paused
+     * @dev Emits `FeeAddressUpdated` event on success
      */
     function updateFeeAddress(address account) external override onlyGov onlyUnpaused {
         require(account != address(0), "Account cannot be 0 address");

--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -96,7 +96,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @dev This is the entry point to upkeep a market
      * @dev Only callable by the associated `PoolKeeper` contract
      * @dev Only callable if the market is *not* paused
-     *
      */
     function poolUpkeep(int256 _oldPrice, int256 _newPrice) external override onlyKeeper onlyUnpaused {
         require(intervalPassed(), "Update interval hasn't passed");
@@ -114,7 +113,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      *         long and short pool, and true if the keeper can successfully be paid out
      * @dev Only callable by the associated `PoolKeeper` contract
      * @dev Only callable when the market is *not* paused
-     *
      */
     function payKeeperFromBalances(address to, uint256 amount)
         external
@@ -152,7 +150,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param amount Amount of quote tokens being transferred
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
-     *
      */
     function quoteTokenTransfer(address to, uint256 amount) external override onlyPoolCommitter onlyUnpaused {
         IERC20(quoteToken).safeTransfer(to, amount);
@@ -165,7 +162,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param amount Amount of quote tokens being transferred
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
-     *
      */
     function poolTokenTransfer(
         bool isLongToken,
@@ -186,7 +182,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param amount Amount of quote tokens being transferred
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
-     *
      */
     function quoteTokenTransferFrom(
         address from,
@@ -205,7 +200,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @dev Only callable when the market is *not* paused
      * @dev Emits `PoolRebalance` if execution succeeds
      * @dev Emits `PriceChangeError` if execution does not take place
-     *
      */
     function executePriceChange(int256 _oldPrice, int256 _newPrice) internal onlyUnpaused {
         // prevent a division by 0 in computing the price change
@@ -244,7 +238,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @notice Execute the fee transfer transactions. Transfers fees to primary fee address (DAO) and secondary (pool deployer).
      *         If the DAO is the fee deployer, secondary fee address should be address(0) and all fees go to DAO.
      * @param totalFeeAmount total amount of fees paid
-     *
      */
     function feeTransfer(uint256 totalFeeAmount) internal {
         if (secondaryFeeAddress == address(0)) {
@@ -263,7 +256,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param _shortBalance New balance of the short pool
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
-     *
      */
     function setNewPoolBalances(uint256 _longBalance, uint256 _shortBalance)
         external
@@ -282,7 +274,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param minter Address of user/minter
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
-     *
      */
     function mintTokens(
         bool isLongToken,
@@ -304,7 +295,6 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @param burner Address of user/burner
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
-     *
      */
     function burnTokens(
         bool isLongToken,
@@ -429,10 +419,18 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         return IOracleWrapper(oracleWrapper).getPrice();
     }
 
+    /**
+     * @return Addresses of the pool tokens for this pool (long and short,
+     *          respectively)
+     */
     function poolTokens() external view override returns (address[2] memory) {
         return tokens;
     }
 
+    /**
+     * @return Quantities of pool tokens for this pool (long and short,
+     *          respectively)
+     */
     function balances() external view override returns (uint256, uint256) {
         return (shortBalance, longBalance);
     }
@@ -441,6 +439,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
      * @notice Withdraws all available quote asset from the pool
      * @dev Pool must not be paused
      * @dev ERC20 transfer
+     * @dev Only callable by governance
      */
     function withdrawQuote() external onlyGov {
         require(paused, "Pool is live");

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -358,6 +358,16 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         }
     }
 
+    /**
+     * @notice Updates the aggregate balance based on the result of application
+     *          of the provided (user) commitment
+     * @param _commit Commitment to apply
+     * @return _newLongTokens Quantity of long pool tokens post-application
+     * @return _newShortTokens Quantity of short pool tokens post-application
+     * @return _newSettlementTokens Quantity of settlement tokens post
+     *                                  application
+     * @dev Wraps two (pure) library functions from `PoolSwapLibrary`
+     */
     function updateBalanceSingleCommitment(UserCommitment memory _commit)
         internal
         view

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -344,6 +344,8 @@ contract PoolCommitter is IPoolCommitter, Initializable {
          * At each iteration, execute all of the (total) commitments for the
          * pool for that period and then remove them from the queue.
          *
+         * In reality, this should never iterate more than once, since more than one update interval
+         * should never be passed without the previous one being upkept.
          */
         while (true) {
             if (block.timestamp >= lastPriceTimestamp + updateInterval * counter) {

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -41,7 +41,6 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @notice Constructor
      * @param _factory Address of the associated `PoolFactory` contract
      * @dev Throws if factory address is null
-     *
      */
     constructor(address _factory) {
         require(_factory != address(0), "Factory address cannot be null");
@@ -52,7 +51,6 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @notice Initialises the contract
      * @param _factory Address of the associated `PoolFactory` contract
      * @dev Throws if factory address is null
-     *
      */
     function initialize(address _factory) external override initializer {
         require(_factory != address(0), "Factory address cannot be 0 address");
@@ -519,7 +517,6 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @param _leveragedPool Address of the pool to use
      * @dev Only callable by the associated `PoolFactory` contract
      * @dev Throws if either address are null
-     *
      */
     function setQuoteAndPool(address _quoteToken, address _leveragedPool) external override onlyFactory {
         require(_quoteToken != address(0), "Quote token address cannot be 0 address");
@@ -534,7 +531,6 @@ contract PoolCommitter is IPoolCommitter, Initializable {
 
     /**
      * @notice Aggregates user balances **prior** to executing the wrapped code
-     *
      */
     modifier updateBalance() {
         updateAggregateBalance(msg.sender);
@@ -543,7 +539,6 @@ contract PoolCommitter is IPoolCommitter, Initializable {
 
     /**
      * @notice Asserts that the caller is the associated `PoolFactory` contract
-     *
      */
     modifier onlyFactory() {
         require(msg.sender == factory, "Committer: not factory");
@@ -552,7 +547,6 @@ contract PoolCommitter is IPoolCommitter, Initializable {
 
     /**
      * @notice Asserts that the caller is the associated `LeveragedPool` contract
-     *
      */
     modifier onlyPool() {
         require(msg.sender == leveragedPool, "msg.sender not leveragedPool");

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -146,6 +146,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      *               tokens you want to burn
      * @param fromAggregateBalance If minting, burning, or rebalancing into a delta neutral position,
      *                             will tokens be taken from user's aggregate balance?
+     * @dev Emits a `CreateCommit` event on success
      */
     function commit(
         CommitType commitType,
@@ -195,6 +196,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @notice Claim user's balance. This can be done either by the user themself or by somebody else on their behalf.
      * @param user Address of the user to claim against
      * @dev Updates aggregate user balances
+     * @dev Emits a `Claim` event on success
      */
     function claim(address user) external override updateBalance {
         Balance memory balance = userAggregateBalance[user];

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -93,7 +93,6 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @dev Throws if deployer does not own the oracle wrapper
      * @dev Throws if leverage amount is invalid
      * @dev Throws if decimal precision is too high (i.e., greater than `MAX_DECIMALS`)
-     *
      */
     function deployPool(PoolDeployment calldata deploymentParameters) external override returns (address) {
         address _poolKeeper = address(poolKeeper);
@@ -170,7 +169,6 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @param deploymentParameters Deployment parameters for parent function
      * @param direction Long or short token, L- or S-
      * @return Address of the pool token
-     *
      */
     function deployPairToken(
         address owner,
@@ -199,7 +197,6 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @param _poolKeeper Address of the `PoolKeeper`
      * @dev Throws if provided address is null
      * @dev Only callable by the owner
-     *
      */
     function setPoolKeeper(address _poolKeeper) external override onlyOwner {
         require(_poolKeeper != address(0), "address cannot be null");
@@ -211,7 +208,6 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @param newMaxLeverage Maximum leverage permitted for all pools
      * @dev Throws if provided maximum leverage is non-positive
      * @dev Only callable by the owner
-     *
      */
     function setMaxLeverage(uint16 newMaxLeverage) external override onlyOwner {
         require(newMaxLeverage > 0, "Maximum leverage must be non-zero");
@@ -227,7 +223,6 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @notice Set the yearly fee amount. The max yearly fee is 10%
      * @dev This is a percentage in WAD; multiplied by 10^18 e.g. 5% is 0.05 * 10^18
      * @param _fee The fee amount as a percentage
-     *
      */
     function setFee(uint256 _fee) external override onlyOwner {
         require(_fee <= 0.1e18, "Fee cannot be >10%");
@@ -238,7 +233,6 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @notice Returns the address that owns this contract
      * @return Address of the owner
      * @dev Required due to the `IPoolFactory` interface
-     *
      */
     function getOwner() external view override returns (address) {
         return owner();

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -240,7 +240,6 @@ contract PoolFactory is IPoolFactory, Ownable {
 
     /**
      * @notice Ensures that the caller is the designated governance address
-     *
      */
     modifier onlyGov() {
         require(msg.sender == owner(), "msg.sender not governance");

--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -101,7 +101,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @dev Tracks gas usage via `gasleft` accounting and uses this to inform
      *          keeper payment
      * @dev Catches any failure of the underlying `pool.poolUpkeep` call
-     *
      */
     function performUpkeepSinglePool(address _pool) public override {
         uint256 startGas = gasleft();
@@ -145,7 +144,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @param pools Addresses of each pool to upkeep
      * @dev Iterates over the provided array
      * @dev Essentially wraps calls to `performUpkeepSinglePool`
-     *
      */
     function performUpkeepMultiplePools(address[] calldata pools) external override {
         uint256 poolsLength = pools.length;
@@ -163,7 +161,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @param _updateInterval Pool interval of the given pool
      * @dev Emits a `KeeperPaid` event if the underlying call to `pool.payKeeperFromBalances` succeeds
      * @dev Emits a `KeeperPaymentError` event otherwise
-     *
      */
     function payKeeper(
         address _pool,
@@ -189,7 +186,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @param _savedPreviousUpdatedTimestamp Last timestamp when the pool's price execution happened
      * @param _poolInterval Pool interval of the given pool
      * @return Number of settlement tokens to give to the keeper for work performed
-     *
      */
     function keeperReward(
         address _pool,
@@ -246,7 +242,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @param _gasPrice Price of a single gas unit (in ETH (wei))
      * @param _gasSpent Number of gas units spent
      * @return Keeper's gas compensation
-     *
      */
     function keeperGas(
         address _pool,
@@ -272,7 +267,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @param _savedPreviousUpdatedTimestamp Last timestamp when the pool's price execution happened
      * @param _poolInterval Pool interval of the given pool
      * @return Percent of the `keeperGas` cost to add to payment, as a percent
-     *
      */
     function keeperTip(uint256 _savedPreviousUpdatedTimestamp, uint256 _poolInterval) public view returns (uint256) {
         /* the number of blocks that have elapsed since the given pool's updateInterval passed */
@@ -292,7 +286,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @notice Sets the address of the associated `PoolFactory` contract
      * @param _factory Address of the `PoolFactory` contract
      * @dev Only callable by the owner
-     *
      */
     function setFactory(address _factory) external override onlyOwner {
         factory = IPoolFactory(_factory);
@@ -310,7 +303,6 @@ contract PoolKeeper is IPoolKeeper, Ownable {
 
     /**
      * @notice Ensures that the caller is the associated `PoolFactory` contract
-     *
      */
     modifier onlyFactory() {
         require(msg.sender == address(factory), "Caller not factory");

--- a/contracts/implementation/PoolSwapLibrary.sol
+++ b/contracts/implementation/PoolSwapLibrary.sol
@@ -45,7 +45,6 @@ library PoolSwapLibrary {
      * @param _numerator The "parts per" side of the equation. If this is zero, the ratio is zero
      * @param _denominator The "per part" side of the equation. If this is zero, the ratio is zero
      * @return the ratio, as an ABDKMathQuad number (IEEE 754 quadruple precision floating point)
-     *
      */
     function getRatio(uint256 _numerator, uint256 _denominator) public pure returns (bytes16) {
         // Catch the divide by zero error.
@@ -198,7 +197,6 @@ library PoolSwapLibrary {
      * @return Resulting long balance
      * @return Resulting short balance
      * @return Total fees (across both long and short sides) resulting from this price change
-     *
      */
     function calculatePriceChange(PriceChangeData calldata priceChange)
         external
@@ -394,7 +392,6 @@ library PoolSwapLibrary {
      * @dev amount * price, where amount is in PoolToken and price is in USD/PoolToken
      * @dev Throws if price is zero
      * @dev `getMint()`
-     *
      */
     function getBurn(bytes16 price, uint256 amount) public pure returns (uint256) {
         require(price != 0, "price == 0");
@@ -409,7 +406,6 @@ library PoolSwapLibrary {
      * @param amountBurnedInstantMint The amount of pool tokens that were burnt from the opposite side for an instant mint in this side
      * @return Quantity of pool tokens to mint
      * @dev Throws if price is zero
-     *
      */
     function getMintWithBurns(
         bytes16 price,
@@ -430,7 +426,6 @@ library PoolSwapLibrary {
      * @param _wadValue wad number
      * @param _decimals Quantity of decimal places to support
      * @return Converted (non-WAD) value
-     *
      */
     function fromWad(uint256 _wadValue, uint256 _decimals) external pure returns (uint256) {
         uint256 scaler = 10**(MAX_DECIMALS - _decimals);
@@ -443,7 +438,6 @@ library PoolSwapLibrary {
      * @return _newLongTokens Quantity of additional long tokens the user would receive
      * @return _newShortTokens Quantity of additional short tokens the user would receive
      * @return _newSettlementTokens Quantity of additional settlement tokens the user would receive
-     *
      */
     function getUpdatedAggregateBalance(UpdateData calldata data)
         external

--- a/contracts/implementation/PoolSwapLibrary.sol
+++ b/contracts/implementation/PoolSwapLibrary.sol
@@ -377,7 +377,6 @@ library PoolSwapLibrary {
      * @return Quantity of pool tokens to mint
      * @dev Throws if price is zero
      * @dev `getBurn()`
-     *
      */
     function getMint(bytes16 price, uint256 amount) public pure returns (uint256) {
         require(price != 0, "price == 0");

--- a/contracts/implementation/PriceObserver.sol
+++ b/contracts/implementation/PriceObserver.sol
@@ -42,7 +42,7 @@ contract PriceObserver is Ownable, IPriceObserver {
 
     /**
      * @notice Retrieves the `i`th price observation
-     * @param Period to retrieve the price observation of
+     * @param i Period to retrieve the price observation of
      * @return `i`th price observation
      * @dev Throws if index is out of bounds (i.e., `i >= length()`)
      *
@@ -97,7 +97,7 @@ contract PriceObserver is Ownable, IPriceObserver {
 
     /**
      * @notice Returns the current writer of this contract
-     * @returns Address of the writer for this contract
+     * @return Address of the writer for this contract
      * @dev `writer`
      *
      */
@@ -107,7 +107,7 @@ contract PriceObserver is Ownable, IPriceObserver {
 
     /**
      * @notice Determines whether or not the backing array is full
-     * @returns Flag indicating whether the backing array is full or not
+     * @return Flag indicating whether the backing array is full or not
      * @dev `length() == capacity()`
      *
      */

--- a/contracts/implementation/PriceObserver.sol
+++ b/contracts/implementation/PriceObserver.sol
@@ -137,7 +137,6 @@ contract PriceObserver is Ownable, IPriceObserver {
     /**
      * @notice Enforces that the caller is the associated writer of this
      *          contract
-     *
      */
     modifier onlyWriter() {
         require(msg.sender == writer, "PO: Permission denied");

--- a/contracts/implementation/PriceObserver.sol
+++ b/contracts/implementation/PriceObserver.sol
@@ -23,7 +23,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      *          number of price observations able to be stored by this contract)
      * @return Maximum number of price observations that can be stored
      * @dev `MAX_NUM_ELEMS`
-     *
      */
     function capacity() public pure override returns (uint256) {
         return MAX_NUM_ELEMS;
@@ -34,7 +33,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @return Current number of price observations stored
      * @dev Should always be less than or equal to `capacity`
      * @dev `numElems`
-     *
      */
     function length() public view override returns (uint256) {
         return numElems;
@@ -45,7 +43,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @param i Period to retrieve the price observation of
      * @return `i`th price observation
      * @dev Throws if index is out of bounds (i.e., `i >= length()`)
-     *
      */
     function get(uint256 i) public view override returns (int256) {
         require(i < length(), "PO: Out of bounds");
@@ -57,7 +54,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @return Backing array of all price observations
      * @dev Note that, due to this view simply returning a reference to the
      *      backing array, it's possible for there to be null prices (i.e., 0)
-     *
      */
     function getAll() public view override returns (int256[24] memory) {
         return observations;
@@ -70,7 +66,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @dev If the backing array is full (i.e., `length() == capacity()`, then
      *      it is rotated such that the oldest price observation is deleted
      * @dev Only callable by the associated writer for this contract
-     *
      */
     function add(int256 x) public override onlyWriter returns (bool) {
         if (full()) {
@@ -88,7 +83,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @param _writer Address of the new writer
      * @dev Only callable by the owner of this contract
      * @dev Throws if `_writer` is the null address
-     *
      */
     function setWriter(address _writer) public onlyOwner {
         require(_writer != address(0), "PO: Null address not allowed");
@@ -99,7 +93,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @notice Returns the current writer of this contract
      * @return Address of the writer for this contract
      * @dev `writer`
-     *
      */
     function getWriter() public view returns (address) {
         return writer;
@@ -109,7 +102,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @notice Determines whether or not the backing array is full
      * @return Flag indicating whether the backing array is full or not
      * @dev `length() == capacity()`
-     *
      */
     function full() private view returns (bool) {
         return length() == capacity();
@@ -118,7 +110,6 @@ contract PriceObserver is Ownable, IPriceObserver {
     /**
      * @notice Resets the backing array and clears all of its stored prices
      * @dev Only callable by the owner of this contract
-     *
      */
     function clear() public onlyOwner {
         numElems = 0;
@@ -129,7 +120,6 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @notice Rotates observations array to the **left** by one element and
      *          sets the last element of `xs` to `x`
      * @param x Element to "rotate into" observations array
-     *
      */
     function leftRotateWithPad(int256 x) private {
         uint256 n = length();

--- a/contracts/implementation/PriceObserver.sol
+++ b/contracts/implementation/PriceObserver.sol
@@ -4,29 +4,74 @@ pragma solidity 0.8.7;
 import "../interfaces/IPriceObserver.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+/// Stores a finite sequence of price observations
 contract PriceObserver is Ownable, IPriceObserver {
+    /// Maximum number of elements storable by the backing array
     uint256 public constant MAX_NUM_ELEMS = 24;
+
+    /// Current number of elements stored by the backing array
     uint256 public numElems = 0;
+
+    /// Backing array for storing price data
     int256[MAX_NUM_ELEMS] public observations;
+
+    /// Writer -- only address allowed to add data to the backing array
     address writer = address(0);
 
+    /**
+     * @notice Returns the capacity of the backing array (i.e., the maximum
+     *          number of price observations able to be stored by this contract)
+     * @return Maximum number of price observations that can be stored
+     * @dev `MAX_NUM_ELEMS`
+     *
+     */
     function capacity() public pure override returns (uint256) {
         return MAX_NUM_ELEMS;
     }
 
+    /**
+     * @notice Returns the current number of price observations stored
+     * @return Current number of price observations stored
+     * @dev Should always be less than or equal to `capacity`
+     * @dev `numElems`
+     *
+     */
     function length() public view override returns (uint256) {
         return numElems;
     }
 
+    /**
+     * @notice Retrieves the `i`th price observation
+     * @param Period to retrieve the price observation of
+     * @return `i`th price observation
+     * @dev Throws if index is out of bounds (i.e., `i >= length()`)
+     *
+     */
     function get(uint256 i) public view override returns (int256) {
         require(i < length(), "PO: Out of bounds");
         return observations[i];
     }
 
+    /**
+     * @notice Retrieves all price observations
+     * @return Backing array of all price observations
+     * @dev Note that, due to this view simply returning a reference to the
+     *      backing array, it's possible for there to be null prices (i.e., 0)
+     *
+     */
     function getAll() public view override returns (int256[24] memory) {
         return observations;
     }
 
+    /**
+     * @notice Adds a new price observation to the contract
+     * @param x Price
+     * @return Whether or not an existing price observation was rotated out
+     * @dev If the backing array is full (i.e., `length() == capacity()`, then
+     *      it is rotated such that the oldest price observation is deleted
+     * @dev Only callable by the associated writer for this contract
+     *
+     */
     function add(int256 x) public override onlyWriter returns (bool) {
         if (full()) {
             leftRotateWithPad(x);
@@ -38,26 +83,51 @@ contract PriceObserver is Ownable, IPriceObserver {
         }
     }
 
+    /**
+     * @notice Sets the associated writer address for this contract
+     * @param _writer Address of the new writer
+     * @dev Only callable by the owner of this contract
+     * @dev Throws if `_writer` is the null address
+     *
+     */
     function setWriter(address _writer) public onlyOwner {
         require(_writer != address(0), "PO: Null address not allowed");
         writer = _writer;
     }
 
+    /**
+     * @notice Returns the current writer of this contract
+     * @returns Address of the writer for this contract
+     * @dev `writer`
+     *
+     */
     function getWriter() public view returns (address) {
         return writer;
     }
 
+    /**
+     * @notice Determines whether or not the backing array is full
+     * @returns Flag indicating whether the backing array is full or not
+     * @dev `length() == capacity()`
+     *
+     */
     function full() private view returns (bool) {
         return length() == capacity();
     }
 
+    /**
+     * @notice Resets the backing array and clears all of its stored prices
+     * @dev Only callable by the owner of this contract
+     *
+     */
     function clear() public onlyOwner {
         numElems = 0;
         delete observations;
     }
 
     /**
-     * @notice Rotates observations array to the **left** by one element and sets the last element of `xs` to `x`
+     * @notice Rotates observations array to the **left** by one element and
+     *          sets the last element of `xs` to `x`
      * @param x Element to "rotate into" observations array
      *
      */
@@ -69,11 +139,16 @@ contract PriceObserver is Ownable, IPriceObserver {
             observations[i - 1] = observations[i];
         }
 
-        /* rotate `x` into `observations` from the right (remember, we're **left**
-         * rotating -- with padding!) */
+        /* rotate `x` into `observations` from the right (remember, we're
+         * **left** rotating -- with padding!) */
         observations[n - 1] = x;
     }
 
+    /**
+     * @notice Enforces that the caller is the associated writer of this
+     *          contract
+     *
+     */
     modifier onlyWriter() {
         require(msg.sender == writer, "PO: Permission denied");
         _;

--- a/contracts/implementation/SMAOracle.sol
+++ b/contracts/implementation/SMAOracle.sol
@@ -57,7 +57,6 @@ contract SMAOracle is IOracleWrapper {
      * @notice Converts `wad` to a raw integer
      * @param wad wad maths value
      * @return Raw (signed) integer
-     *
      */
     function fromWad(int256 wad) external view override returns (int256) {
         return wad / scaler;
@@ -66,7 +65,6 @@ contract SMAOracle is IOracleWrapper {
     /**
      * @notice Retrieves the current SMA price
      * @dev Recomputes SMA across sample size (`periods`)
-     *
      */
     function getPrice() external view override returns (int256) {
         /* update current reported SMA price */
@@ -78,7 +76,6 @@ contract SMAOracle is IOracleWrapper {
      * @dev O(n) complexity (with n being `capacity`) due to rotation of
      *      underlying observations array and subsequent recalculation of SMA
      *      price
-     *
      */
     function update() internal returns (int256) {
         /* query the underlying spot price oracle */
@@ -118,7 +115,6 @@ contract SMAOracle is IOracleWrapper {
      * @dev Note that the signedness of the return type is due to the signedness of the elements of `xs`
      * @dev It's a true tragedy that we have to stipulate a fixed-length array for `xs`, but alas, Solidity's type system cannot
      *          reason about this at all due to the value's runtime requirement
-     *
      */
     function SMA(int256[24] memory xs, uint256 k) public pure returns (int256) {
         uint256 n = xs.length;

--- a/contracts/implementation/SMAOracle.sol
+++ b/contracts/implementation/SMAOracle.sol
@@ -57,11 +57,17 @@ contract SMAOracle is IOracleWrapper {
      * @notice Converts `wad` to a raw integer
      * @param wad wad maths value
      * @return Raw (signed) integer
+     *
      */
     function fromWad(int256 wad) external view override returns (int256) {
         return wad / scaler;
     }
 
+    /**
+     * @notice Retrieves the current SMA price
+     * @dev Recomputes SMA across sample size (`periods`)
+     *
+     */
     function getPrice() external view override returns (int256) {
         /* update current reported SMA price */
         return SMA(IPriceObserver(observer).getAll(), periods);
@@ -87,6 +93,14 @@ contract SMAOracle is IOracleWrapper {
         return SMA(priceObserver.getAll(), periods);
     }
 
+    /**
+     * @notice Updates the SMA oracle by retrieving a new price from the
+     *          associated price observer contract (provided it's not too early)
+     * @return Latest SMA price
+     * @dev Throws if called within an update interval since last being called
+     * @dev Essentially wraps `update()`
+     *
+     */
     function poll() external override returns (int256) {
         require(block.timestamp >= lastUpdate + updateInterval, "SMA: Too early to update");
         return update();

--- a/contracts/implementation/SMAOracle.sol
+++ b/contracts/implementation/SMAOracle.sol
@@ -96,7 +96,6 @@ contract SMAOracle is IOracleWrapper {
      * @return Latest SMA price
      * @dev Throws if called within an update interval since last being called
      * @dev Essentially wraps `update()`
-     *
      */
     function poll() external override returns (int256) {
         require(block.timestamp >= lastUpdate + updateInterval, "SMA: Too early to update");


### PR DESCRIPTION
# Motivation
Various aspects of the codebase are currently lacking NatSpec-formatted doc comments or the quality of the existing ones is lacking (due to rapid changes, API modifications, etc.). The clarity of the codebase is paramount -- particularly with respect to auditing. This PR aims to remedy this.

# Changes
 - Add missing doc comments to `PoolCommitter`
 - Add missing doc comments to `PoolKeeper`
 - Add missing doc comments to `PoolFactory`
 - Add missing doc comments to `LeveragedPool`
 - Add missing doc comments to `PriceObserver`
 - Add missing doc comments to `SMAOracle`
 - Add missing doc comments to `PoolSwapLibrary`

# Acceptance Criteria
TBA
