### PR TITLE
Fix tests not awaiting

### DIFF
--- a/test/LeveragedPool/poolUpkeep.spec.ts
+++ b/test/LeveragedPool/poolUpkeep.spec.ts
@@ -132,7 +132,7 @@ describe("LeveragedPool - executeAllCommitments", () => {
     it("Paused pools cannot upkeep", async () => {
         await timeout(updateInterval * 1000)
         await pool.pause()
-        expect(pool.poolUpkeep(lastPrice, lastPrice)).to.revertedWith(
+        await expect(pool.poolUpkeep(lastPrice, lastPrice)).to.revertedWith(
             "Pool is paused"
         )
     })

--- a/test/LeveragedPool/transferFees.spec.ts
+++ b/test/LeveragedPool/transferFees.spec.ts
@@ -124,36 +124,30 @@ describe("LeveragedPool - feeTransfer", () => {
         beforeEach(async () => {
             await pool.pause()
         })
-        it("Quote token transfer", async () => {
-            expect(pool.quoteTokenTransfer(feeAddress, 123)).to.revertedWith(
-                "Pool is paused"
-            )
-        })
-        it("Pool token transfer", async () => {
-            expect(
-                pool.poolTokenTransfer(true, feeAddress, 123)
-            ).to.revertedWith("Pool is paused")
-        })
-        it("Quote token transfer From", async () => {
-            expect(
-                pool.quoteTokenTransferFrom(feeAddress, pool.address, 123)
+        it("Commit should be paused", async () => {
+            await expect(
+                poolCommitter.commit(LONG_BURN, 123, false)
             ).to.revertedWith("Pool is paused")
         })
         it("Update fee address", async () => {
-            expect(pool.updateFeeAddress(secondFeeAddress)).to.revertedWith(
+            await expect(
+                pool.updateFeeAddress(secondFeeAddress)
+            ).to.revertedWith("Pool is paused")
+        })
+        it("Set keeper", async () => {
+            await expect(pool.setKeeper(feeAddress)).to.revertedWith(
                 "Pool is paused"
             )
         })
-        it("Set keeper", async () => {
-            expect(pool.setKeeper(feeAddress)).to.revertedWith("Pool is paused")
-        })
         it("Transfer governnance", async () => {
-            expect(pool.transferGovernance(feeAddress)).to.revertedWith(
+            await expect(pool.transferGovernance(feeAddress)).to.revertedWith(
                 "Pool is paused"
             )
         })
         it("Claim governnance", async () => {
-            expect(pool.claimGovernance()).to.revertedWith("Pool is paused")
+            await expect(pool.claimGovernance()).to.revertedWith(
+                "Pool is paused"
+            )
         })
     })
 })


### PR DESCRIPTION
Motivation: Some tests are secretly broken but not showing up unless u look into the CLI when you run node.
Changes: Fix broken tests by awaiting them which they previously weren't.