### PR TITLE
Parameterise fee split percentage

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -32,6 +32,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
     bool public governanceTransferInProgress;
     address public feeAddress;
     address public secondaryFeeAddress;
+    uint256 public secondaryFeeSplitPercent; // Split to secondary fee address as a percentage.
     address public override quoteToken;
     address public override poolCommitter;
     address public override oracleWrapper;
@@ -58,8 +59,8 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         require(initialization._longToken != address(0), "Long token cannot be 0 address");
         require(initialization._shortToken != address(0), "Short token cannot be 0 address");
         require(initialization._poolCommitter != address(0), "PoolCommitter cannot be 0 address");
-
         require(initialization._fee < PoolSwapLibrary.WAD_PRECISION, "Fee >= 100%");
+        require(initialization._secondaryFeeSplitPercent <= 100, "percent cannot exceed 100");
 
         // set the owner of the pool. This is governance when deployed from the factory
         governance = initialization._owner;
@@ -75,6 +76,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         leverageAmount = PoolSwapLibrary.convertUIntToDecimal(initialization._leverageAmount);
         feeAddress = initialization._feeAddress;
         secondaryFeeAddress = initialization._secondaryFeeAddress;
+        secondaryFeeSplitPercent = initialization._secondaryFeeSplitPercent;
         lastPriceTimestamp = block.timestamp;
         poolName = initialization._poolName;
         tokens[LONG_INDEX] = initialization._longToken;
@@ -243,10 +245,11 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         if (secondaryFeeAddress == address(0)) {
             IERC20(quoteToken).safeTransfer(feeAddress, totalFeeAmount);
         } else {
-            uint256 daoFee = PoolSwapLibrary.mulFraction(totalFeeAmount, 9, 10);
-            uint256 remainder = totalFeeAmount - daoFee;
-            IERC20(quoteToken).safeTransfer(feeAddress, daoFee);
-            IERC20(quoteToken).safeTransfer(secondaryFeeAddress, remainder);
+            require(secondaryFeeSplitPercent <= 100, "percent cannot exceed 100");
+            uint256 secondaryFee = PoolSwapLibrary.mulFraction(totalFeeAmount, secondaryFeeSplitPercent, 100);
+            uint256 remainder = totalFeeAmount - secondaryFee;
+            IERC20(quoteToken).safeTransfer(secondaryFeeAddress, secondaryFee);
+            IERC20(quoteToken).safeTransfer(feeAddress, remainder);
         }
     }
 

--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -60,7 +60,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         require(initialization._shortToken != address(0), "Short token cannot be 0 address");
         require(initialization._poolCommitter != address(0), "PoolCommitter cannot be 0 address");
         require(initialization._fee < PoolSwapLibrary.WAD_PRECISION, "Fee >= 100%");
-        require(initialization._secondaryFeeSplitPercent <= 100, "percent cannot exceed 100");
+        require(initialization._secondaryFeeSplitPercent <= 100, "Secondary fee split cannot exceed 100%");
 
         // set the owner of the pool. This is governance when deployed from the factory
         governance = initialization._owner;
@@ -245,7 +245,7 @@ contract LeveragedPool is ILeveragedPool, Initializable {
         if (secondaryFeeAddress == address(0)) {
             IERC20(quoteToken).safeTransfer(feeAddress, totalFeeAmount);
         } else {
-            require(secondaryFeeSplitPercent <= 100, "percent cannot exceed 100");
+            require(secondaryFeeSplitPercent <= 100, "Secondary fee split cannot exceed 100%");
             uint256 secondaryFee = PoolSwapLibrary.mulFraction(totalFeeAmount, secondaryFeeSplitPercent, 100);
             uint256 remainder = totalFeeAmount - secondaryFee;
             IERC20(quoteToken).safeTransfer(secondaryFeeAddress, secondaryFee);

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -218,13 +218,25 @@ contract PoolFactory is IPoolFactory, Ownable {
         maxLeverage = newMaxLeverage;
     }
 
+    /**
+    * @notice Sets the primary fee receiver of deployed Leveraged pools.
+    * @param _feeReceiver address of fee receiver
+    * @dev Only callable by the owner of this contract
+    * @dev This fuction does not change anything for already deployed pools, only pools deployed after the change
+    */
     function setFeeReceiver(address _feeReceiver) external override onlyOwner {
         require(_feeReceiver != address(0), "address cannot be null");
         feeReceiver = _feeReceiver;
     }
 
+    /**
+    * @notice Sets the proportion of fees to be split to the nominated secondary fees recipient
+    * @param newFeePercent Proportion of fees to split
+    * @dev Only callable by the owner of this contract
+    * @dev Throws if `newFeePercent` exceeds 100
+    */
     function setSecondaryFeeSplitPercent(uint256 newFeePercent) external override onlyOwner {
-        require(newFeePercent <= 100, "percent cannot exceed 100");
+        require(newFeePercent <= 100, "Secondary fee split cannot exceed 100%");
         secondaryFeeSplitPercent = newFeePercent;
     }
 

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -31,6 +31,8 @@ contract PoolFactory is IPoolFactory, Ownable {
     address public feeReceiver;
     // Default fee; Fee value as a decimal multiplied by 10^18. For example, 0.5% is represented as 0.5 * 10^18
     uint256 public fee;
+    // Percent of fees that go to secondary fee address if applicable.
+    uint256 public secondaryFeeSplitPercent = 10;
 
     // This is required because we must pass along *some* value for decimal
     // precision to the base pool tokens as we use the Cloneable pattern
@@ -76,7 +78,8 @@ contract PoolFactory is IPoolFactory, Ownable {
             1,
             address(this),
             address(0),
-            address(this)
+            address(this),
+            secondaryFeeSplitPercent
         );
         // Init bases
         poolBase.initialize(baseInitialization);
@@ -146,7 +149,8 @@ contract PoolFactory is IPoolFactory, Ownable {
             deploymentParameters.leverageAmount,
             feeReceiver,
             msg.sender,
-            deploymentParameters.quoteToken
+            deploymentParameters.quoteToken,
+            secondaryFeeSplitPercent
         );
 
         // approve the quote token on the pool committer to finalise linking
@@ -217,6 +221,11 @@ contract PoolFactory is IPoolFactory, Ownable {
     function setFeeReceiver(address _feeReceiver) external override onlyOwner {
         require(_feeReceiver != address(0), "address cannot be null");
         feeReceiver = _feeReceiver;
+    }
+
+    function setSecondaryFeeSplitPercent(uint256 newFeePercent) external override onlyOwner {
+        require(newFeePercent <= 100, "percent cannot exceed 100");
+        secondaryFeeSplitPercent = newFeePercent;
     }
 
     /**

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -219,22 +219,22 @@ contract PoolFactory is IPoolFactory, Ownable {
     }
 
     /**
-    * @notice Sets the primary fee receiver of deployed Leveraged pools.
-    * @param _feeReceiver address of fee receiver
-    * @dev Only callable by the owner of this contract
-    * @dev This fuction does not change anything for already deployed pools, only pools deployed after the change
-    */
+     * @notice Sets the primary fee receiver of deployed Leveraged pools.
+     * @param _feeReceiver address of fee receiver
+     * @dev Only callable by the owner of this contract
+     * @dev This fuction does not change anything for already deployed pools, only pools deployed after the change
+     */
     function setFeeReceiver(address _feeReceiver) external override onlyOwner {
         require(_feeReceiver != address(0), "address cannot be null");
         feeReceiver = _feeReceiver;
     }
 
     /**
-    * @notice Sets the proportion of fees to be split to the nominated secondary fees recipient
-    * @param newFeePercent Proportion of fees to split
-    * @dev Only callable by the owner of this contract
-    * @dev Throws if `newFeePercent` exceeds 100
-    */
+     * @notice Sets the proportion of fees to be split to the nominated secondary fees recipient
+     * @param newFeePercent Proportion of fees to split
+     * @dev Only callable by the owner of this contract
+     * @dev Throws if `newFeePercent` exceeds 100
+     */
     function setSecondaryFeeSplitPercent(uint256 newFeePercent) external override onlyOwner {
         require(newFeePercent <= 100, "Secondary fee split cannot exceed 100%");
         secondaryFeeSplitPercent = newFeePercent;

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -20,6 +20,7 @@ interface ILeveragedPool {
         address _feeAddress; // The address that the fund movement fee is sent to
         address _secondaryFeeAddress; // The address of fee recieved by third party deployers
         address _quoteToken; //  The digital asset that the pool accepts. Must have a decimals() function
+        uint256 _secondaryFeeSplitPercent; // Percent of fees that go to secondary fee address if it exists
     }
 
     // #### Events

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -49,6 +49,6 @@ interface IPoolFactory {
     function setFee(uint256 _fee) external;
 
     function setSecondaryFeeSplitPercent(uint256 newFeePercent) external;
-    
+
     function setMintAndBurnFee(uint256 _mintingFee, uint256 _burningFee) external;
 }

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -52,4 +52,6 @@ interface IPoolFactory {
     function setFeeReceiver(address _feeReceiver) external;
 
     function setFee(uint256 _fee) external;
+
+    function setSecondaryFeeSplitPercent(uint256 newFeePercent) external;
 }

--- a/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
+++ b/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
@@ -34,6 +34,7 @@ contract LeveragedPoolBalanceDrainMock is ILeveragedPool, Initializable, IPausab
     bool public governanceTransferInProgress;
     address public feeAddress;
     address public secondaryFeeAddress;
+    uint256 public secondaryFeeSplitPercent; // Split to secondary fee address as a percentage.
     address public override quoteToken;
     address public override poolCommitter;
     address public override oracleWrapper;

--- a/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
+++ b/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
@@ -31,6 +31,7 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
     address public feeReceiver;
     // Default fee; Fee value as a decimal multiplied by 10^18. For example, 0.5% is represented as 0.5 * 10^18
     uint256 public fee;
+    uint256 public secondaryFeeSplitPercent = 10;
 
     // This is required because we must pass along *some* value for decimal
     // precision to the base pool tokens as we use the Cloneable pattern
@@ -75,7 +76,8 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
             1,
             address(this),
             address(0),
-            address(this)
+            address(this),
+            10
         );
         // Init bases
         poolBase.initialize(baseInitialization);
@@ -141,7 +143,8 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
             _leverageAmount: deploymentParameters.leverageAmount,
             _feeAddress: feeReceiver,
             _secondaryFeeAddress: msg.sender,
-            _quoteToken: deploymentParameters.quoteToken
+            _quoteToken: deploymentParameters.quoteToken,
+            _secondaryFeeSplitPercent: secondaryFeeSplitPercent
         });
 
         // approve the quote token on the pool committer to finalise linking
@@ -208,6 +211,11 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
     function setFeeReceiver(address _feeReceiver) external override onlyOwner {
         require(_feeReceiver != address(0), "address cannot be null");
         feeReceiver = _feeReceiver;
+    }
+
+    function setSecondaryFeeSplitPercent(uint256 newFeePercent) external override onlyOwner {
+        require(newFeePercent <= 100, "Secondary fee split cannot exceed 100%");
+        secondaryFeeSplitPercent = newFeePercent;
     }
 
     /**

--- a/test/InvariantCheck/balanceInvariant.spec.ts
+++ b/test/InvariantCheck/balanceInvariant.spec.ts
@@ -87,6 +87,7 @@ describe("InvariantCheck - balanceInvariant", () => {
                 _secondaryFeeAddress: feeAddress,
                 _quoteToken: quoteToken,
                 _invariantCheckContract: invariantCheck.address,
+                _secondaryFeeSplitPercent: 10
             })
 
             await result.token.approve(result.pool.address, amountMinted)

--- a/test/InvariantCheck/balanceInvariant.spec.ts
+++ b/test/InvariantCheck/balanceInvariant.spec.ts
@@ -87,7 +87,7 @@ describe("InvariantCheck - balanceInvariant", () => {
                 _secondaryFeeAddress: feeAddress,
                 _quoteToken: quoteToken,
                 _invariantCheckContract: invariantCheck.address,
-                _secondaryFeeSplitPercent: 10
+                _secondaryFeeSplitPercent: 10,
             })
 
             await result.token.approve(result.pool.address, amountMinted)

--- a/test/LeveragedPool/initialize.spec.ts
+++ b/test/LeveragedPool/initialize.spec.ts
@@ -226,12 +226,9 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: quoteToken,
-<<<<<<< HEAD
                     _secondaryFeeSplitPercent: 10,
-=======
                     _invariantCheckContract:
                         setupContracts.invariantCheck.address,
->>>>>>> pools-v2
                 })
             ).wait()
             const event: Event | undefined = receipt?.events?.find(
@@ -309,11 +306,8 @@ describe("LeveragedPool - initialize", () => {
                 _feeAddress: feeAddress,
                 _secondaryFeeAddress: ethers.constants.AddressZero,
                 _quoteToken: quoteToken,
-<<<<<<< HEAD
                 _secondaryFeeSplitPercent: 10,
-=======
                 _invariantCheckContract: invariantCheck.address,
->>>>>>> pools-v2
             })
             await expect(
                 leveragedPool.initialize({
@@ -332,11 +326,8 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: quoteToken,
-<<<<<<< HEAD
                     _secondaryFeeSplitPercent: 10,
-=======
                     _invariantCheckContract: invariantCheck.address,
->>>>>>> pools-v2
                 })
             ).to.rejectedWith(Error)
         })
@@ -358,11 +349,8 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: ethers.constants.AddressZero,
-<<<<<<< HEAD
                     _secondaryFeeSplitPercent: 10,
-=======
                     _invariantCheckContract: invariantCheck.address,
->>>>>>> pools-v2
                 })
             ).to.rejectedWith(Error)
         })
@@ -384,11 +372,8 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: quoteToken,
-<<<<<<< HEAD
                     _secondaryFeeSplitPercent: 10,
-=======
                     _invariantCheckContract: invariantCheck.address,
->>>>>>> pools-v2
                 })
             ).to.rejectedWith(Error)
         })

--- a/test/LeveragedPool/initialize.spec.ts
+++ b/test/LeveragedPool/initialize.spec.ts
@@ -224,6 +224,7 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: quoteToken,
+                    _secondaryFeeSplitPercent: 10,
                 })
             ).wait()
             const event: Event | undefined = receipt?.events?.find(
@@ -299,6 +300,7 @@ describe("LeveragedPool - initialize", () => {
                 _feeAddress: feeAddress,
                 _secondaryFeeAddress: ethers.constants.AddressZero,
                 _quoteToken: quoteToken,
+                _secondaryFeeSplitPercent: 10,
             })
             await expect(
                 leveragedPool.initialize({
@@ -317,6 +319,7 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: quoteToken,
+                    _secondaryFeeSplitPercent: 10,
                 })
             ).to.rejectedWith(Error)
         })
@@ -338,6 +341,7 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: ethers.constants.AddressZero,
+                    _secondaryFeeSplitPercent: 10,
                 })
             ).to.rejectedWith(Error)
         })
@@ -359,6 +363,7 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: feeAddress,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: quoteToken,
+                    _secondaryFeeSplitPercent: 10,
                 })
             ).to.rejectedWith(Error)
         })
@@ -380,6 +385,7 @@ describe("LeveragedPool - initialize", () => {
                     _feeAddress: ethers.constants.AddressZero,
                     _secondaryFeeAddress: ethers.constants.AddressZero,
                     _quoteToken: quoteToken,
+                    _secondaryFeeSplitPercent: 10,
                 })
             ).to.rejectedWith(Error)
         })
@@ -410,6 +416,7 @@ describe("LeveragedPool - initialize", () => {
                 _feeAddress: feeAddress,
                 _secondaryFeeAddress: ethers.constants.AddressZero,
                 _quoteToken: quoteToken,
+                _secondaryFeeSplitPercent: 10,
             })
             await leveragedPool.initialize({
                 _owner: signers[0].address,
@@ -427,6 +434,7 @@ describe("LeveragedPool - initialize", () => {
                 _feeAddress: feeAddress,
                 _secondaryFeeAddress: ethers.constants.AddressZero,
                 _quoteToken: quoteToken,
+                _secondaryFeeSplitPercent: 10,
             })
 
             expect(await secondPool.poolName()).to.eq(POOL_CODE_2)

--- a/test/LeveragedPool/transferFees.spec.ts
+++ b/test/LeveragedPool/transferFees.spec.ts
@@ -121,11 +121,8 @@ describe("LeveragedPool - feeTransfer", () => {
     })
 
     context("Change fee split percentage", async () => {
-        beforeEach(async () => {
-            
-        })
+        beforeEach(async () => {})
     })
-
 
     context("Test Paused Pools cannot transfer tokens", async () => {
         beforeEach(async () => {

--- a/test/LeveragedPool/transferFees.spec.ts
+++ b/test/LeveragedPool/transferFees.spec.ts
@@ -120,6 +120,13 @@ describe("LeveragedPool - feeTransfer", () => {
         })
     })
 
+    context("Change fee split percentage", async () => {
+        beforeEach(async () => {
+            
+        })
+    })
+
+
     context("Test Paused Pools cannot transfer tokens", async () => {
         beforeEach(async () => {
             await pool.pause()

--- a/test/LeveragedPool/transferFees.spec.ts
+++ b/test/LeveragedPool/transferFees.spec.ts
@@ -120,10 +120,6 @@ describe("LeveragedPool - feeTransfer", () => {
         })
     })
 
-    context("Change fee split percentage", async () => {
-        beforeEach(async () => {})
-    })
-
     context("Test Paused Pools cannot transfer tokens", async () => {
         beforeEach(async () => {
             await pool.pause()

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -11,22 +11,28 @@ import {
     TestToken__factory,
     TestClones,
     TestClones__factory,
+    PoolCommitter,
+    PoolToken,
 } from "../../types"
-import { POOL_CODE, POOL_CODE_2 } from "../constants"
+import { POOL_CODE, POOL_CODE_2, LONG_MINT, SHORT_MINT } from "../constants"
 import {
     deployPoolAndTokenContracts,
     generateRandomAddress,
     getEventArgs,
+    createCommit,
+    timeout,
+    getRandomInt,
 } from "../utilities"
-import { Signer } from "ethers"
+import { Signer, BigNumber } from "ethers"
 import LeveragedPoolInterface from "../../artifacts/contracts/implementation/LeveragedPool.sol/LeveragedPool.json"
-import { deflateRaw } from "zlib"
+import { abi as ERC20Abi } from "../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json"
 
 const updateInterval = 100
 const frontRunningInterval = 20
-const fee = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5]
+const fee = ethers.utils.parseEther("0.1")
 const leverage = 1
 const feeAddress = generateRandomAddress()
+const secondFeeAddress = generateRandomAddress()
 
 chai.use(chaiAsPromised)
 const { expect } = chai
@@ -285,27 +291,106 @@ describe("PoolFactory.deployPool", () => {
                 oracleWrapper: oracleWrapper.address,
                 settlementEthOracle: settlementEthOracle.address,
             }
-            
+
             const poolNumber = (await factory.numPools()).toNumber()
             await factory.deployPool(deploymentData)
             const oldPoolAddress = await factory.pools(0)
-            const oldPool = await ethers.getContractAt("LeveragedPool", oldPoolAddress) as LeveragedPool
+            const oldPool = (await ethers.getContractAt(
+                "LeveragedPool",
+                oldPoolAddress
+            )) as LeveragedPool
             const newPoolAddress = await factory.pools(poolNumber)
-            const newPool = await ethers.getContractAt("LeveragedPool", newPoolAddress) as LeveragedPool
-            
-            const oldFeeSplit = (await oldPool.secondaryFeeSplitPercent()).toNumber()
-            const newFeeSplit = (await newPool.secondaryFeeSplitPercent()).toNumber()
+            const newPool = (await ethers.getContractAt(
+                "LeveragedPool",
+                newPoolAddress
+            )) as LeveragedPool
+
+            const oldFeeSplit = (
+                await oldPool.secondaryFeeSplitPercent()
+            ).toNumber()
+            const newFeeSplit = (
+                await newPool.secondaryFeeSplitPercent()
+            ).toNumber()
             expect(oldFeeSplit).to.eq(10)
             expect(newFeeSplit).to.eq(20)
+        })
+
+        it("pool fee transfers new fee split percentage", async () => {
+            const deploymentData = {
+                poolName: POOL_CODE_2,
+                frontRunningInterval: 3,
+                updateInterval: 5,
+                leverageAmount: 2,
+                quoteToken: token.address,
+                oracleWrapper: oracleWrapper.address,
+                settlementEthOracle: settlementEthOracle.address,
+            }
+
+            const poolNumber = (await factory.numPools()).toNumber()
+            await factory.deployPool(deploymentData)
+            const newPoolAddress = await factory.pools(poolNumber)
+            const newPool = (await ethers.getContractAt(
+                "LeveragedPool",
+                newPoolAddress
+            )) as LeveragedPool
+
+            let commiter = await newPool.poolCommitter()
+            const poolCommitter = (await ethers.getContractAt(
+                "PoolCommitter",
+                commiter
+            )) as PoolCommitter
+
+            // Make commits
+            await token.approve(
+                newPool.address,
+                ethers.utils.parseEther("10000")
+            )
+            await createCommit(
+                poolCommitter,
+                LONG_MINT,
+                ethers.utils.parseEther("2000")
+            )
+            await createCommit(
+                poolCommitter,
+                SHORT_MINT,
+                ethers.utils.parseEther("2000")
+            )
+            const signers = await ethers.getSigners()
+            await newPool.setKeeper(signers[0].address)
+            newPool.updateSecondaryFeeAddress(secondFeeAddress)
+
+            // Execute commits no price change
+            await timeout(updateInterval * 1000)
+            const lastPrice = ethers.utils.parseEther(
+                getRandomInt(99999999, 1).toString()
+            )
+            await newPool.poolUpkeep(lastPrice, lastPrice)
+
+            // Upkeep pool with price change
+            await timeout(updateInterval * 1000)
+            await newPool.poolUpkeep(
+                lastPrice,
+                BigNumber.from("2").mul(lastPrice)
+            )
+
+            let feesPaidPrimary = await token.balanceOf(feeAddress)
+            let feesPaidSecondary = await token.balanceOf(secondFeeAddress)
+            expect(
+                parseFloat(ethers.utils.formatEther(feesPaidPrimary)) /
+                    parseFloat(ethers.utils.formatEther(feesPaidSecondary))
+            ).to.eq(4)
         })
     })
 
     context("When secondary fee split is changed too high", async () => {
         it("change fee split to 100 should revert error", async () => {
-            await expect(factory.setSecondaryFeeSplitPercent(100)).to.not.reverted
+            await expect(factory.setSecondaryFeeSplitPercent(100)).to.not
+                .reverted
         })
         it("change fee split to > 100 should revert error", async () => {
-            await expect(factory.setSecondaryFeeSplitPercent(200)).to.revertedWith("Secondary fee split cannot exceed 100%")
+            await expect(
+                factory.setSecondaryFeeSplitPercent(200)
+            ).to.revertedWith("Secondary fee split cannot exceed 100%")
         })
     })
 })

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -299,4 +299,13 @@ describe("PoolFactory.deployPool", () => {
             expect(newFeeSplit).to.eq(20)
         })
     })
+
+    context("When secondary fee split is changed too high", async () => {
+        it("change fee split to 100 should revert error", async () => {
+            await expect(factory.setSecondaryFeeSplitPercent(100)).to.not.reverted
+        })
+        it("change fee split to > 100 should revert error", async () => {
+            await expect(factory.setSecondaryFeeSplitPercent(200)).to.revertedWith("Secondary fee split cannot exceed 100%")
+        })
+    })
 })

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -104,6 +104,7 @@ describe("PoolFactory.deployPool", () => {
                 _feeAddress: generateRandomAddress(),
                 _secondaryFeeAddress: ethers.constants.AddressZero,
                 _quoteToken: token.address,
+                _secondaryFeeSplitPercent: 10,
             }
             await expect(pool.initialize(initialization)).to.be.rejectedWith(
                 Error

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -382,12 +382,15 @@ describe("PoolFactory.deployPool", () => {
         })
     })
 
-    context("When secondary fee split is changed too high", async () => {
-        it("change fee split to 100 should revert error", async () => {
+    context("When secondary fee split is == 100", async () => {
+        it("Does not revert", async () => {
             await expect(factory.setSecondaryFeeSplitPercent(100)).to.not
                 .reverted
         })
-        it("change fee split to > 100 should revert error", async () => {
+    })
+
+    context("When secondary fee split is > 100", async () => {
+        it("Reverts", async () => {
             await expect(
                 factory.setSecondaryFeeSplitPercent(200)
             ).to.revertedWith("Secondary fee split cannot exceed 100%")

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -300,7 +300,7 @@ describe("PoolFactory.deployPool", () => {
                 quoteToken: token.address,
                 oracleWrapper: oracleWrapper.address,
                 settlementEthOracle: settlementEthOracle.address,
-                invariantCheckContract: invariantCheck.address
+                invariantCheckContract: invariantCheck.address,
             }
 
             const poolNumber = (await factory.numPools()).toNumber()
@@ -335,7 +335,7 @@ describe("PoolFactory.deployPool", () => {
                 quoteToken: token.address,
                 oracleWrapper: oracleWrapper.address,
                 settlementEthOracle: settlementEthOracle.address,
-                invariantCheckContract: invariantCheck.address
+                invariantCheckContract: invariantCheck.address,
             }
 
             const poolNumber = (await factory.numPools()).toNumber()

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -300,6 +300,7 @@ describe("PoolFactory.deployPool", () => {
                 quoteToken: token.address,
                 oracleWrapper: oracleWrapper.address,
                 settlementEthOracle: settlementEthOracle.address,
+                invariantCheckContract: invariantCheck.address
             }
 
             const poolNumber = (await factory.numPools()).toNumber()
@@ -334,6 +335,7 @@ describe("PoolFactory.deployPool", () => {
                 quoteToken: token.address,
                 oracleWrapper: oracleWrapper.address,
                 settlementEthOracle: settlementEthOracle.address,
+                invariantCheckContract: invariantCheck.address
             }
 
             const poolNumber = (await factory.numPools()).toNumber()


### PR DESCRIPTION
Motivation: The fee split percentage between third party deployer and dao for perpetual pools right now is a hardcoded split 90/10. I anticipate the business might want to change this in future post deployment. Maybe to increase to incentivise third party deployments more. It seems low cost to make this a variable that we can modify and could save us lots of headache when we want to change in future.

Changes: Parameterise fee split percentage in PoolFactory and make it modifiable by factory owner/governor. So when factory deploys pool it will set its fee split percent to whatever the parameter is. After factory deploys pool, the pools fee split percent is fixed to whatever it was at time of deployment.