### PR TITLE
Autoclaim

### DIFF
--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -43,7 +43,7 @@ contract AutoClaim is IAutoClaim, Initializable {
             if (requestUpdateIntervalId < poolCommitter.updateIntervalId()) {
                 // If so, this person may as well claim for themself (if allowed). They have signified their want of claim, after all.
                 // Note that this function is only called by PoolCommitter when a user `commits` and therefore `user` will always equal the original `msg.sender`.
-                // send(msg.sender, request.reward);
+                payable(msg.sender).transfer(claimRequests[user][msg.sender].reward);
                 delete claimRequests[user][msg.sender];
                 poolCommitter.claim(user);
             } else {
@@ -73,7 +73,7 @@ contract AutoClaim is IAutoClaim, Initializable {
         // Check if a previous claim request has been made, and if it is claimable.
         if (checkClaim(request, currentUpdateIntervalId)) {
             // Send the reward to msg.sender.
-            // send(msg.sender, request.reward);
+            payable(msg.sender).transfer(claimRequests[user][poolCommitterAddress].reward);
             // delete the ClaimRequest from storage
             delete claimRequests[user][poolCommitterAddress];
             // execute the claim
@@ -120,7 +120,7 @@ contract AutoClaim is IAutoClaim, Initializable {
      */
     function withdrawClaimRequest(address poolCommitter) external override {
         if (checkUserClaim(msg.sender, poolCommitter)) {
-            // send(claimRequests[msg.sender][poolCommitter].reward, msg.sender);
+            payable(msg.sender).transfer(claimRequests[msg.sender][poolCommitter].reward);
             delete claimRequests[msg.sender][poolCommitter];
         }
     }
@@ -130,7 +130,7 @@ contract AutoClaim is IAutoClaim, Initializable {
      * @param user The user who will have their claim request withdrawn.
      */
     function withdrawUserClaimRequest(address user) public override onlyPoolCommitter {
-        // send(claimRequests[user][poolCommitter].reward, msg.sender);
+        payable(user).transfer(claimRequests[user][msg.sender].reward);
         delete claimRequests[user][msg.sender];
     }
 

--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -1,0 +1,90 @@
+//SPDX-License-Identifier: CC-BY-NC-ND-4.0
+pragma solidity 0.8.7;
+
+import "../interfaces/IPoolCommitter.sol";
+import "../interfaces/IAutoClaim.sol";
+
+/// @title The contract to be used for paying to have a keeper claim your commit automatically
+/// @notice The way this works is when a user commits with `PoolCommitter::commit`, they have the option to set the `bool payForClaim` parameter to `true`.
+///         During this function execution, `AutoClaim::payForClaim` is called, and `msg.value` is taken as the reward to whoever claims for requester (by using `AutoClaim::payedClaim`).
+/// @dev A question I had to ask was "What happens if one requests a second claim before one's pending request from a previous update interval one gets executed on?".
+///      My solution to this was to have the committer instantly claim for themself. They have signified their desire to claim their tokens, after all.
+contract AutoClaim is IAutoClaim {
+    mapping(address => ClaimRequest) claimRequests;
+    address internal poolCommitterAddress;
+    IPoolCommitter internal poolCommitter;
+
+    constructor(address _poolCommitterAddress) {
+        require(_poolCommitterAddress != address(0), "PoolCommitter address == 0");
+        poolCommitterAddress = _poolCommitterAddress;
+        poolCommitter = IPoolCommitter(_poolCommitterAddress);
+    }
+
+    /**
+     * @notice Pay for your commit to be claimed. This means that a willing participant can claim on `user`'s behalf when the current update interval ends.
+     * @dev Only callable by this contract's associated PoolCommitter instance. This prevents griefing. Consider a permissionless function, where a user can claim that somebody else wants to auto claim when they do not.
+     * @param user The user who wants to autoclaim.
+     */
+    function makePaidClaimRequest(address user) external payable override onlyPoolCommitter {
+        ClaimRequest storage request = claimRequests[user];
+
+        uint256 requestUpdateIntervalId = request.updateIntervalId;
+        // Check if a previous claim request is pending...
+        if (requestUpdateIntervalId > 0) {
+            // and if it is claimable (the current update interval is greater than the one where the request was made).
+            if (requestUpdateIntervalId < poolCommitter.updateIntervalId()) {
+                // If so, this person may as well claim for themself (if allowed). They have signified their want of claim, after all.
+                // Note that this function is only called by PoolCommitter when a user `commits` and therefore `user` will always equal the original `msg.sender`.
+                // send(msg.sender, request.reward);
+                delete claimRequests[user];
+                poolCommitter.claim(user);
+            } else {
+                // If the claim request is pending but not yet valid (it was made in the current commit), we want to add to the value.
+                // Note that in context, the user *usually* won't need or want to increment `ClaimRequest.reward` more than once because the first call to `payForClaim` should suffice.
+                request.reward += msg.value;
+            }
+        } else {
+            // If no previous claim requests are pending, we need to make a new one.
+            request.updateIntervalId = poolCommitter.updateIntervalId();
+            request.reward = msg.value;
+        }
+    }
+
+    /**
+     * @notice Claim on the behalf of a user who has requests to have their commit automatically claimed by a keeper.
+     * @param user The user who requested an autoclaim.
+     */
+    function payedClaim(address user) external override {
+        ClaimRequest memory request = claimRequests[user];
+        uint256 currentUpdateIntervalId = poolCommitter.updateIntervalId();
+        // Check if a previous claim request has been made, and if it is claimable.
+        if (checkClaim(request, currentUpdateIntervalId)) {
+            // Send the reward to msg.sender.
+            // send(msg.sender, request.reward);
+            // delete the ClaimRequest from storage
+            delete claimRequests[user];
+            // execute the claim
+            poolCommitter.claim(user);
+        }
+    }
+
+    /**
+     * @return true if the given claim request can be executed.
+     * @dev A claim request can be executed only if one exists and is from an update interval that has passed.
+     * @param request The ClaimRequest object to be checked.
+     * @param currentUpdateIntervalId The current update interval. Used to compare to the update interval of the ClaimRequest.
+     */
+    function checkClaim(ClaimRequest memory request, uint256 currentUpdateIntervalId)
+        public
+        pure
+        override
+        returns (bool)
+    {
+        return request.updateIntervalId > 0 && request.updateIntervalId < currentUpdateIntervalId;
+    }
+
+    modifier onlyPoolCommitter() {
+        require(msg.sender == poolCommitterAddress, "msg.sender != poolCommitter");
+        _;
+    }
+}

--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -119,6 +119,7 @@ contract AutoClaim is IAutoClaim, Initializable {
     /**
      * @notice If a user's claim request never gets executed (due to not high enough of a reward), or they change their minds, enable them to withdraw their request.
      * @param poolCommitter The PoolCommitter for which the user's commit claim is to be withdrawn.
+     * @dev Emits a `RequestWithdrawn` event on success
      */
     function withdrawClaimRequest(address poolCommitter) external override {
         if (claimRequests[msg.sender][poolCommitter].updateIntervalId > 0) {
@@ -131,6 +132,7 @@ contract AutoClaim is IAutoClaim, Initializable {
     /**
      * @notice When the user claims themself through poolCommitter, you want the
      * @param user The user who will have their claim request withdrawn.
+     * @dev Only callable by the associated `PoolCommitter` contract
      */
     function withdrawUserClaimRequest(address user) public override onlyPoolCommitter {
         payable(user).transfer(claimRequests[user][msg.sender].reward);

--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -56,7 +56,7 @@ contract AutoClaim is IAutoClaim, Initializable {
         }
 
         // If no previous claim requests are pending, we need to make a new one.
-        requestUpdateIntervalId = poolCommitter.updateIntervalId();
+        requestUpdateIntervalId = poolCommitter.getAppropriateUpdateIntervalId();
         claimRequests[user][msg.sender].updateIntervalId = requestUpdateIntervalId;
         claimRequests[user][msg.sender].reward = msg.value;
         emit PaidClaimRequestUpdate(user, msg.sender, msg.value);
@@ -121,9 +121,10 @@ contract AutoClaim is IAutoClaim, Initializable {
      * @param poolCommitter The PoolCommitter for which the user's commit claim is to be withdrawn.
      */
     function withdrawClaimRequest(address poolCommitter) external override {
-        if (checkUserClaim(msg.sender, poolCommitter)) {
+        if (claimRequests[msg.sender][poolCommitter].updateIntervalId > 0) {
             payable(msg.sender).transfer(claimRequests[msg.sender][poolCommitter].reward);
             delete claimRequests[msg.sender][poolCommitter];
+            emit RequestWithdrawn(msg.sender, poolCommitter);
         }
     }
 

--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -79,7 +79,7 @@ contract AutoClaim is IAutoClaim, Initializable {
             delete claimRequests[user][poolCommitterAddress];
             // execute the claim
             poolCommitter.claim(user);
-            emit PaidRequestExecution(user, request.reward);
+            emit PaidRequestExecution(user, poolCommitterAddress, request.reward);
         }
     }
 
@@ -113,8 +113,6 @@ contract AutoClaim is IAutoClaim, Initializable {
             paidClaim(users[i], poolCommitterAddress);
         }
     }
-
-    // todo add ufnction for msg.sender to make their own autoclaim request outside of commitment
 
     /**
      * @notice If a user's claim request never gets executed (due to not high enough of a reward), or they change their minds, enable them to withdraw their request.

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -57,7 +57,8 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @param _autoClaim Address of the associated `AutoClaim` contract
      * @param _mintingFee The percentage that is taken from each mint, given as a decimal * 10 ^ 18
      * @param _burningFee The percentage that is taken from each burn, given as a decimal * 10 ^ 18
-     * @dev Throws if factory address is null
+     * @dev Throws if factory contract address is null
+     * @dev Throws if autoClaim contract address is null
      * @dev Throws if invariantCheck contract address is null
      * @dev Throws if minting fee is over 100%
      * @dev Throws if burning fee is over 100%
@@ -89,7 +90,8 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @param _autoClaim Address of the associated `AutoClaim` contract
      * @param _mintingFee The percentage that is taken from each mint, given as a decimal * 10 ^ 18
      * @param _burningFee The percentage that is taken from each burn, given as a decimal * 10 ^ 18
-     * @dev Throws if factory address is null
+     * @dev Throws if factory contract address is null
+     * @dev Throws if autoClaim contract address is null
      * @dev Throws if invariantCheck contract address is null
      * @dev Throws if autoclaim contract address is null
      * @dev Only callable by the associated initialiser address

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -81,6 +81,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         require(_factory != address(0), "Factory address cannot be 0 address");
         require(_invariantCheckContract != address(0), "InvariantCheck address cannot be 0 address");
         require(_autoClaim != address(0), "AutoClaim address cannot be null");
+        updateIntervalId = 1;
         factory = _factory;
         autoClaim = IAutoClaim(_autoClaim);
         governance = IPoolFactory(_factory).getOwner();
@@ -507,6 +508,24 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         balance.settlementTokens += update._newSettlementTokensSum;
 
         emit AggregateBalanceUpdated(user);
+    }
+
+    /**
+     * @return which update interval ID a commit would be placed into if made now
+     * @dev Calls PoolSwapLibrary::appropriateUpdateIntervalId
+     */
+    function getAppropriateUpdateIntervalId() external view override returns (uint128) {
+        ILeveragedPool pool = ILeveragedPool(leveragedPool);
+        return
+            uint128(
+                PoolSwapLibrary.appropriateUpdateIntervalId(
+                    block.timestamp,
+                    pool.lastPriceTimestamp(),
+                    pool.frontRunningInterval(),
+                    pool.updateInterval(),
+                    updateIntervalId
+                )
+            );
     }
 
     /**

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "./PoolSwapLibrary.sol";
+import "hardhat/console.sol";
 
 /// @title This contract is responsible for handling commitment logic
 contract PoolCommitter is IPoolCommitter, Initializable {
@@ -50,7 +51,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         require(_factory != address(0), "Factory address cannot be 0 address");
         require(_autoClaim != address(0), "AutoClaim address cannot be null");
         factory = _factory;
-        autoClaim = IAutoClaim(autoClaim);
+        autoClaim = IAutoClaim(_autoClaim);
     }
 
     /**
@@ -195,10 +196,15 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @notice Claim user's balance. This can be done either by the user themself or by somebody else on their behalf.
      */
     function claim(address user) external override updateBalance onlyAutoClaimOrCommitter(user) {
+        console.log("claim start");
+        console.log(address(autoClaim));
         if (msg.sender == user && autoClaim.checkUserClaim(user, address(this))) {
             // If the committer is claiming for themself and they have a valid pending claim, clear it.
+            console.log("hi");
             autoClaim.withdrawUserClaimRequest(user);
+            console.log("succeeded");
         }
+        console.log("claim continue");
         Balance memory balance = userAggregateBalance[user];
         ILeveragedPool pool = ILeveragedPool(leveragedPool);
         if (balance.settlementTokens > 0) {

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -11,7 +11,6 @@ import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "./PoolSwapLibrary.sol";
-import "hardhat/console.sol";
 
 /// @title This contract is responsible for handling commitment logic
 contract PoolCommitter is IPoolCommitter, Initializable {
@@ -191,8 +190,6 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         uint256 frontRunningInterval = pool.frontRunningInterval();
 
         if (payForClaim) {
-            // TODO I am not sure if this actually passes on the msg.value but think it does
-            console.log(msg.value);
             autoClaim.makePaidClaimRequest{value: msg.value}(msg.sender);
         }
 
@@ -235,13 +232,8 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @dev Updates aggregate user balances
      * @dev Emits a `Claim` event on success
      */
-    function claim(address user)
-        external
-        override
-        updateBalance
-        checkInvariantsAfterFunction
-        onlyAutoClaimOrCommitter(user)
-    {
+    function claim(address user) external override checkInvariantsAfterFunction onlyAutoClaimOrCommitter(user) {
+        updateAggregateBalance(user);
         if (msg.sender == user && autoClaim.checkUserClaim(user, address(this))) {
             // If the committer is claiming for themself and they have a valid pending claim, clear it.
             autoClaim.withdrawUserClaimRequest(user);

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -15,8 +15,9 @@ contract PoolCommitter is IPoolCommitter, Initializable {
     uint128 public constant LONG_INDEX = 0;
     uint128 public constant SHORT_INDEX = 1;
 
+    address public autoClaim;
     address public leveragedPool;
-    uint128 public updateIntervalId = 1;
+    uint128 public override updateIntervalId = 1;
     // Index 0 is the LONG token, index 1 is the SHORT token.
     // Fetched from the LeveragedPool when leveragedPool is set
     address[2] public tokens;
@@ -460,10 +461,16 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         return _balance;
     }
 
-    function setQuoteAndPool(address _quoteToken, address _leveragedPool) external override onlyFactory {
+    function setQuoteAutoClaimAndPool(
+        address _quoteToken,
+        address _autoClaim,
+        address _leveragedPool
+    ) external override onlyFactory {
         require(_quoteToken != address(0), "Quote token address cannot be 0 address");
+        require(_autoClaim != address(0), "AutoClaim address cannot be 0 address");
         require(_leveragedPool != address(0), "Leveraged pool address cannot be 0 address");
 
+        autoClaim = _autoClaim;
         leveragedPool = _leveragedPool;
         IERC20 _token = IERC20(_quoteToken);
         bool approvalSuccess = _token.approve(leveragedPool, _token.totalSupply());

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -9,6 +9,7 @@ import "./LeveragedPool.sol";
 import "./PoolToken.sol";
 import "./PoolKeeper.sol";
 import "./PoolCommitter.sol";
+import "./AutoClaim.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
@@ -151,7 +152,11 @@ contract PoolFactory is IPoolFactory, Ownable {
         pool.initialize(initialization);
         // approve the quote token on the pool commiter to finalise linking
         // this also stores the pool address in the commiter
-        IPoolCommitter(poolCommitterAddress).setQuoteAndPool(deploymentParameters.quoteToken, _pool);
+        IPoolCommitter(poolCommitterAddress).setQuoteAutoClaimAndPool(
+            deploymentParameters.quoteToken,
+            _pool, // TODO CHANGE THIS TO AutoClaim
+            _pool
+        );
         poolKeeper.newPool(_pool);
         pools[numPools] = _pool;
         numPools += 1;

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -64,7 +64,7 @@ contract PoolFactory is IPoolFactory, Ownable {
         pairTokenBaseAddress = address(pairTokenBase);
         poolBase = new LeveragedPool();
         poolBaseAddress = address(poolBase);
-        poolCommitterBase = new PoolCommitter(address(this), address(this));
+        poolCommitterBase = new PoolCommitter(address(this), address(this), address(this));
         poolCommitterBaseAddress = address(poolCommitterBase);
 
         ILeveragedPool.Initialization memory baseInitialization = ILeveragedPool.Initialization(
@@ -88,7 +88,6 @@ contract PoolFactory is IPoolFactory, Ownable {
         // Init bases
         poolBase.initialize(baseInitialization);
         pairTokenBase.initialize(address(this), "BASE_TOKEN", "BASE", DEFAULT_NUM_DECIMALS);
-        poolCommitterBase.initialize(address(this), address(this));
         feeReceiver = _feeReceiver;
     }
 
@@ -168,6 +167,7 @@ contract PoolFactory is IPoolFactory, Ownable {
         pools[numPools] = _pool;
         numPools += 1;
         isValidPool[_pool] = true;
+        isValidPoolCommitter[poolCommitterAddress] = true;
         return _pool;
     }
 

--- a/contracts/interfaces/IAutoClaim.sol
+++ b/contracts/interfaces/IAutoClaim.sol
@@ -10,6 +10,8 @@ interface IAutoClaim {
         uint256 reward; // The amount of ETH in wei that was given by the user to pay for upkeep
     }
 
+    function initialize(address _poolFactoryAddress) external;
+
     /**
      * @notice Pay for your commit to be claimed. This means that a willing participant can claim on `user`'s behalf when the current update interval ends.
      * @dev Only callable by this contract's associated PoolCommitter instance. This prevents griefing. Consider a permissionless function, where a user can claim that somebody else wants to auto claim when they do not.
@@ -21,7 +23,13 @@ interface IAutoClaim {
      * @notice Claim on the behalf of a user who has requests to have their commit automatically claimed by a keeper.
      * @param user The user who requested an autoclaim.
      */
-    function payedClaim(address user) external;
+    function paidClaim(address user) external;
+
+    /**
+     * @notice Call `paidClaim` for multiple users.
+     * @param users All users to execute claims for.
+     */
+    function multiPaidClaim(address[] calldata users) external;
 
     /**
      * @return true if the given claim request can be executed.

--- a/contracts/interfaces/IAutoClaim.sol
+++ b/contracts/interfaces/IAutoClaim.sol
@@ -10,6 +10,7 @@ interface IAutoClaim {
     );
     event PaidClaimRequestUpdate(address indexed user, address indexed poolCommitter, uint256 indexed newReward);
     event PaidRequestExecution(address user, uint256 reward);
+    event RequestWithdrawn(address user, address poolCommitter);
 
     struct ClaimRequest {
         uint128 updateIntervalId; // The update interval during which a user requested a claim.

--- a/contracts/interfaces/IAutoClaim.sol
+++ b/contracts/interfaces/IAutoClaim.sol
@@ -2,7 +2,13 @@
 pragma solidity 0.8.7;
 
 interface IAutoClaim {
-    event PaidRequestClaim(address indexed user, uint256 indexed updateIntervalId, uint256 indexed reward);
+    event PaidClaimRequest(
+        address indexed user,
+        address indexed poolCommitter,
+        uint256 indexed updateIntervalId,
+        uint256 reward
+    );
+    event PaidClaimRequestUpdate(address indexed user, address indexed poolCommitter, uint256 indexed newReward);
     event PaidRequestExecution(address user, uint256 reward);
 
     struct ClaimRequest {
@@ -22,14 +28,46 @@ interface IAutoClaim {
     /**
      * @notice Claim on the behalf of a user who has requests to have their commit automatically claimed by a keeper.
      * @param user The user who requested an autoclaim.
+     * @param poolCommitterAddress The PoolCommitter address within which the user's claim will be executed
      */
-    function paidClaim(address user) external;
+    function paidClaim(address user, address poolCommitterAddress) external;
 
     /**
-     * @notice Call `paidClaim` for multiple users.
+     * @notice Call `paidClaim` for multiple users, across multiple PoolCommitters
      * @param users All users to execute claims for.
+     * @param poolCommitterAddresses The PoolCommitter addresses within which you would like to claim for the respective user
+     * @dev The nth index in poolCommitterAddresses should be the PoolCommitter where the nth address in user requested an auto claim
      */
-    function multiPaidClaim(address[] calldata users) external;
+    function multiPaidClaimMultiplePoolCommitters(address[] calldata users, address[] calldata poolCommitterAddresses)
+        external;
+
+    /**
+     * @notice Call `paidClaim` for multiple users, in a single PoolCommitter.
+     * @dev The nth index in poolCommitterAddresses should be the PoolCommitter where the nth address in user requested an auto claim
+     * @param users All users to execute claims for.
+     * @param poolCommitterAddress The PoolCommitter address within which you would like to claim for the respective user
+     */
+    function multiPaidClaimSinglePoolCommitter(address[] calldata users, address poolCommitterAddress) external;
+
+    /**
+     * @notice If a user's claim request never gets executed (due to not high enough of a reward), or they change their minds, enable them to withdraw their request.
+     * @param poolCommitter The PoolCommitter for which the user's commit claim is to be withdrawn.
+     */
+    function withdrawClaimRequest(address poolCommitter) external;
+
+    /**
+     * @notice When the user claims themself through poolCommitter, you want the
+     * @param user The user who will have their claim request withdrawn.
+     */
+    function withdrawUserClaimRequest(address user) external;
+
+    /**
+     * @notice Check the validity of a user's claim request for a given pool committer.
+     * @return true if the claim request can be executed.
+     * @param user The user whose claim request will be checked.
+     * @param poolCommitter The pool committer in which to look for a user's claim request.
+     */
+    function checkUserClaim(address user, address poolCommitter) external view returns (bool);
 
     /**
      * @return true if the given claim request can be executed.

--- a/contracts/interfaces/IAutoClaim.sol
+++ b/contracts/interfaces/IAutoClaim.sol
@@ -1,0 +1,33 @@
+//SPDX-License-Identifier: CC-BY-NC-ND-4.0
+pragma solidity 0.8.7;
+
+interface IAutoClaim {
+    event PaidRequestClaim(address indexed user, uint256 indexed updateIntervalId, uint256 indexed reward);
+    event PaidRequestExecution(address user, uint256 reward);
+
+    struct ClaimRequest {
+        uint128 updateIntervalId; // The update interval during which a user requested a claim.
+        uint256 reward; // The amount of ETH in wei that was given by the user to pay for upkeep
+    }
+
+    /**
+     * @notice Pay for your commit to be claimed. This means that a willing participant can claim on `user`'s behalf when the current update interval ends.
+     * @dev Only callable by this contract's associated PoolCommitter instance. This prevents griefing. Consider a permissionless function, where a user can claim that somebody else wants to auto claim when they do not.
+     * @param user The user who wants to autoclaim.
+     */
+    function makePaidClaimRequest(address user) external payable;
+
+    /**
+     * @notice Claim on the behalf of a user who has requests to have their commit automatically claimed by a keeper.
+     * @param user The user who requested an autoclaim.
+     */
+    function payedClaim(address user) external;
+
+    /**
+     * @return true if the given claim request can be executed.
+     * @dev A claim request can be executed only if one exists and is from an update interval that has passed.
+     * @param request The ClaimRequest object to be checked.
+     * @param currentUpdateIntervalId The current update interval. Used to compare to the update interval of the ClaimRequest.
+     */
+    function checkClaim(ClaimRequest memory request, uint256 currentUpdateIntervalId) external pure returns (bool);
+}

--- a/contracts/interfaces/IAutoClaim.sol
+++ b/contracts/interfaces/IAutoClaim.sol
@@ -2,14 +2,41 @@
 pragma solidity 0.8.7;
 
 interface IAutoClaim {
+    /**
+     * @notice Creates a notification when an auto-claim is requested
+     * @param user The user who made a request
+     * @param poolCommitter The PoolCommitter instance in which the commit was made
+     * @param updateIntervalId The update interval ID that the corresponding commitment was allocated for
+     * @param reward The reward for the auto-claim
+     */
     event PaidClaimRequest(
         address indexed user,
         address indexed poolCommitter,
         uint256 indexed updateIntervalId,
         uint256 reward
     );
+
+    /**
+     * @notice Creates a notification when an auto-claim request is updated. i.e. When another commit is added and reward is incremented.
+     * @param user The user whose request got updated
+     * @param poolCommitter The PoolCommitter instance in which the commits were made
+     * @param newReward The new total reward for the auto-claim
+     */
     event PaidClaimRequestUpdate(address indexed user, address indexed poolCommitter, uint256 indexed newReward);
-    event PaidRequestExecution(address user, uint256 reward);
+
+    /**
+     * @notice Creates a notification when an auto-claim request is executed
+     * @param user The user whose request got executed
+     * @param poolCommitter The PoolCommitter instance in which the original commit was made
+     * @param reward The reward for the auto-claim
+     */
+    event PaidRequestExecution(address user, address poolCommitter, uint256 reward);
+
+    /**
+     * @notice Creates a notification when an auto-claim request is withdrawn
+     * @param user The user whose request got withdrawn
+     * @param poolCommitter The PoolCommitter instance in which the original commit was made
+     */
     event RequestWithdrawn(address user, address poolCommitter);
 
     struct ClaimRequest {

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -104,6 +104,8 @@ interface IPoolCommitter {
         bool fromAggregateBalance
     ) external;
 
+    function updateIntervalId() external view returns (uint128);
+
     function claim(address user) external;
 
     function executeCommitments() external;
@@ -112,5 +114,9 @@ interface IPoolCommitter {
 
     function getAggregateBalance(address user) external view returns (Balance memory _balance);
 
-    function setQuoteAndPool(address quoteToken, address leveragedPool) external;
+    function setQuoteAutoClaimAndPool(
+        address _quoteToken,
+        address _autoClaim,
+        address _leveragedPool
+    ) external;
 }

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -119,6 +119,8 @@ interface IPoolCommitter {
 
     function getAggregateBalance(address user) external view returns (Balance memory _balance);
 
+    function getAppropriateUpdateIntervalId() external view returns (uint128);
+
     function setQuoteAndPool(address _quoteToken, address _leveragedPool) external;
 
     function getPendingCommits() external view returns (TotalCommitment memory, TotalCommitment memory);

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -96,13 +96,14 @@ interface IPoolCommitter {
 
     // #### Functions
 
-    function initialize(address _factory) external;
+    function initialize(address _factory, address _autoClaim) external;
 
     function commit(
         CommitType commitType,
         uint256 amount,
-        bool fromAggregateBalance
-    ) external;
+        bool fromAggregateBalance,
+        bool payForClaim
+    ) external payable;
 
     function updateIntervalId() external view returns (uint128);
 
@@ -114,9 +115,5 @@ interface IPoolCommitter {
 
     function getAggregateBalance(address user) external view returns (Balance memory _balance);
 
-    function setQuoteAutoClaimAndPool(
-        address _quoteToken,
-        address _autoClaim,
-        address _leveragedPool
-    ) external;
+    function setQuoteAndPool(address _quoteToken, address _leveragedPool) external;
 }

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -40,12 +40,16 @@ interface IPoolFactory {
 
     function isValidPool(address _pool) external view returns (bool);
 
+    function isValidPoolCommitter(address _poolCommitter) external view returns (bool);
+
     // #### Functions
     function deployPool(PoolDeployment calldata deploymentParameters) external returns (address);
 
     function getOwner() external returns (address);
 
     function setPoolKeeper(address _poolKeeper) external;
+
+    function setAutoClaim(address _autoClaim) external;
 
     function setMaxLeverage(uint16 newMaxLeverage) external;
 

--- a/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
+++ b/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
@@ -24,8 +24,7 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
     PoolCommitter public poolCommitterBase;
     address public immutable poolCommitterBaseAddress;
 
-    // Default max leverage of 10
-    uint16 public maxLeverage = 10;
+    address public autoClaim;
 
     // Contract address to receive protocol fees
     address public feeReceiver;
@@ -35,8 +34,9 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
     // This is required because we must pass along *some* value for decimal
     // precision to the base pool tokens as we use the Cloneable pattern
     uint8 constant DEFAULT_NUM_DECIMALS = 18;
-
     uint8 constant MAX_DECIMALS = DEFAULT_NUM_DECIMALS;
+    // Default max leverage of 10
+    uint16 public maxLeverage = 10;
 
     /**
      * @notice Format: Pool counter => pool address
@@ -49,14 +49,21 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
      */
     mapping(address => bool) public override isValidPool;
 
+    /**
+     * @notice Format: PoolCommitter address => validity
+     */
+    mapping(address => bool) public override isValidPoolCommitter;
+
     // #### Functions
     constructor(address _feeReceiver) {
+        require(_feeReceiver != address(0), "Address cannot be null");
+
         // Deploy base contracts
         pairTokenBase = new PoolToken(DEFAULT_NUM_DECIMALS);
         pairTokenBaseAddress = address(pairTokenBase);
         poolBase = new LeveragedPoolBalanceDrainMock();
         poolBaseAddress = address(poolBase);
-        poolCommitterBase = new PoolCommitter(address(this), address(this));
+        poolCommitterBase = new PoolCommitter(address(this), address(this), address(this));
         poolCommitterBaseAddress = address(poolCommitterBase);
 
         ILeveragedPool.Initialization memory baseInitialization = ILeveragedPool.Initialization(
@@ -79,34 +86,40 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
         );
         // Init bases
         poolBase.initialize(baseInitialization);
-
         pairTokenBase.initialize(address(this), "BASE_TOKEN", "BASE", DEFAULT_NUM_DECIMALS);
         feeReceiver = _feeReceiver;
     }
 
     /**
-     * @notice Deploy a leveraged pool with given parameters
-     * @param deploymentParameters Deployment parameters of the market. Some may be reconfigurable
+     * @notice Deploy a leveraged pool and its committer/pool tokens with given parameters
+     * @param deploymentParameters Deployment parameters of the market. Some may be reconfigurable.
      * @return Address of the created pool
+     * @dev Throws if pool keeper is null
+     * @dev Throws if deployer does not own the oracle wrapper
+     * @dev Throws if leverage amount is invalid
+     * @dev Throws if decimal precision is too high (i.e., greater than `MAX_DECIMALS`)
      */
-    function deployPool(PoolDeployment calldata deploymentParameters) external override onlyGov returns (address) {
+    function deployPool(PoolDeployment calldata deploymentParameters) external override returns (address) {
         address _poolKeeper = address(poolKeeper);
         require(_poolKeeper != address(0), "PoolKeeper not set");
+        require(
+            IOracleWrapper(deploymentParameters.oracleWrapper).deployer() == msg.sender,
+            "Deployer must be oracle wrapper owner"
+        );
 
         bytes32 uniquePoolHash = keccak256(
             abi.encode(
                 deploymentParameters.leverageAmount,
                 deploymentParameters.quoteToken,
-                deploymentParameters.oracleWrapper,
-                deploymentParameters.updateInterval,
-                deploymentParameters.frontRunningInterval
+                deploymentParameters.oracleWrapper
             )
         );
 
-        address poolCommitterAddress = clonePoolCommitterBase(
-            uniquePoolHash,
-            deploymentParameters.invariantCheckContract
+        PoolCommitter poolCommitter = PoolCommitter(
+            Clones.cloneDeterministic(poolCommitterBaseAddress, uniquePoolHash)
         );
+        poolCommitter.initialize(address(this), deploymentParameters.invariantCheckContract, autoClaim);
+        address poolCommitterAddress = address(poolCommitter);
 
         require(
             deploymentParameters.leverageAmount >= 1 && deploymentParameters.leverageAmount <= maxLeverage,
@@ -137,7 +150,7 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
             _poolName: string(abi.encodePacked(leverage, "-", deploymentParameters.poolName)),
             _frontRunningInterval: deploymentParameters.frontRunningInterval,
             _updateInterval: deploymentParameters.updateInterval,
-            _fee: fee,
+            _fee: (fee * deploymentParameters.updateInterval) / (365 days),
             _leverageAmount: deploymentParameters.leverageAmount,
             _feeAddress: feeReceiver,
             _secondaryFeeAddress: msg.sender,
@@ -156,14 +169,6 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
         numPools += 1;
         isValidPool[_pool] = true;
         return _pool;
-    }
-
-    function clonePoolCommitterBase(bytes32 uniquePoolHash, address invariantCheckContract) internal returns (address) {
-        PoolCommitter poolCommitter = PoolCommitter(
-            Clones.cloneDeterministic(poolCommitterBaseAddress, uniquePoolHash)
-        );
-        poolCommitter.initialize(address(this), invariantCheckContract);
-        return address(poolCommitter);
     }
 
     /**
@@ -195,11 +200,34 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
         return address(pairToken);
     }
 
+    /**
+     * @notice Sets the address of the associated `PoolKeeper` contract
+     * @param _poolKeeper Address of the `PoolKeeper`
+     * @dev Throws if provided address is null
+     * @dev Only callable by the owner
+     */
     function setPoolKeeper(address _poolKeeper) external override onlyOwner {
         require(_poolKeeper != address(0), "address cannot be null");
         poolKeeper = IPoolKeeper(_poolKeeper);
     }
 
+    /**
+     * @notice Sets the address of the associated `AutoClaim` contract
+     * @param _autoClaim Address of the `AutoClaim`
+     * @dev Throws if provided address is null
+     * @dev Only callable by the owner
+     */
+    function setAutoClaim(address _autoClaim) external override onlyOwner {
+        require(_autoClaim != address(0), "address cannot be null");
+        autoClaim = _autoClaim;
+    }
+
+    /**
+     * @notice Sets the maximum leverage
+     * @param newMaxLeverage Maximum leverage permitted for all pools
+     * @dev Throws if provided maximum leverage is non-positive
+     * @dev Only callable by the owner
+     */
     function setMaxLeverage(uint16 newMaxLeverage) external override onlyOwner {
         require(newMaxLeverage > 0, "Maximum leverage must be non-zero");
         maxLeverage = newMaxLeverage;
@@ -211,18 +239,37 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, Ownable {
     }
 
     /**
-     * @notice Set the fee amount. This is a percentage multiplied by 10^18.
-     *         e.g. 5% is 0.05 * 10^18
-     * @param _fee The fee amount as a percentage multiplied by 10^18
+     * @notice Set the yearly fee amount. The max yearly fee is 10%
+     * @dev This is a percentage in WAD; multiplied by 10^18 e.g. 5% is 0.05 * 10^18
+     * @param _fee The fee amount as a percentage
      */
     function setFee(uint256 _fee) external override onlyOwner {
+        require(_fee <= 0.1e18, "Fee cannot be >10%");
         fee = _fee;
     }
 
+    /**
+     * @notice Sets a valid PoolCommitter.
+     * @dev TEST FUNCTION
+     * @param _address The address whose validity will be toggled.
+     * @param _validity True or false, depending on whether to mark it as valid or not.
+     */
+    function setValidPoolCommitter(address _address, bool _validity) external {
+        isValidPoolCommitter[_address] = _validity;
+    }
+
+    /**
+     * @notice Returns the address that owns this contract
+     * @return Address of the owner
+     * @dev Required due to the `IPoolFactory` interface
+     */
     function getOwner() external view override returns (address) {
         return owner();
     }
 
+    /**
+     * @notice Ensures that the caller is the designated governance address
+     */
     modifier onlyGov() {
         require(msg.sender == owner(), "msg.sender not governance");
         _;

--- a/test/AutoClaim/makePaidClaimRequest.spec.ts
+++ b/test/AutoClaim/makePaidClaimRequest.spec.ts
@@ -1,0 +1,131 @@
+import { ethers } from "hardhat"
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+import {
+    LeveragedPool,
+    TestToken,
+    ERC20,
+    PoolSwapLibrary,
+    PoolCommitter,
+    AutoClaim,
+    PoolKeeper,
+} from "../../types"
+
+import {
+    POOL_CODE,
+    DEFAULT_FEE,
+    LONG_MINT,
+    LONG_BURN,
+    SHORT_MINT,
+} from "../constants"
+import {
+    deployPoolAndTokenContracts,
+    getRandomInt,
+    generateRandomAddress,
+    createCommit,
+    CommitEventArgs,
+    timeout,
+    deployMockPool,
+    getEventArgs,
+} from "../utilities"
+import { BigNumber } from "ethers"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const amountCommitted = ethers.utils.parseEther("2000")
+const amountMinted = ethers.utils.parseEther("10000")
+const feeAddress = generateRandomAddress()
+const lastPrice = ethers.utils.parseEther(getRandomInt(99999999, 1).toString())
+const updateInterval = 200
+const frontRunningInterval = 100 // seconds
+const fee = DEFAULT_FEE
+const leverage = 1
+const reward = 123123
+
+describe("AutoClaim - makePaidClaimRequest", () => {
+    let poolCommitter: PoolCommitter
+    let token: TestToken
+    let shortToken: ERC20
+    let longToken: ERC20
+    let pool: LeveragedPool
+    let library: PoolSwapLibrary
+    let autoClaim: AutoClaim
+    let signers: SignerWithAddress[]
+    let poolKeeper: PoolKeeper
+
+    const commits: CommitEventArgs[] | undefined = []
+    beforeEach(async () => {
+        const result = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee
+        )
+        pool = result.pool
+        library = result.library
+        poolCommitter = result.poolCommitter
+        autoClaim = result.autoClaim
+        signers = result.signers
+        poolKeeper = result.poolKeeper
+
+        token = result.token
+        shortToken = result.shortToken
+        longToken = result.longToken
+
+        await token.approve(pool.address, amountMinted)
+    })
+
+    context("When called from a non-pool committer", async () => {
+        it("reverts", async () => {
+            await expect(autoClaim.makePaidClaimRequest(signers[0].address)).to.be.revertedWith("msg.sender not valid PoolCommitter")
+        })
+    })
+
+    context("When no pending request already exists", async () => {
+        it("adds a new one", async () => {
+            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
+            expect(request.reward).to.equal(reward)
+            expect(request.updateIntervalId).to.equal(await poolCommitter.updateIntervalId())
+        })
+    })
+
+    context("When a pending request already exists, but is not yet ready to be claimed", async () => {
+        it("increments reward", async () => {
+            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
+            expect(request.reward).to.equal(reward * 2) // 2x rewards
+            expect(request.updateIntervalId).to.equal(await poolCommitter.updateIntervalId())
+        })
+    })
+
+    context("When a pending request already exists, and is ready to be claimed", async () => {
+        it("Resets the pending request and executes previous one", async () => {
+            const secondReward = reward - 50
+            await token.transfer(signers[1].address, amountCommitted.mul(2))
+            await token.connect(signers[1]).approve(pool.address, amountMinted)
+            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+
+            const balanceBefore = await ethers.provider.getBalance(signers[1].address)
+
+            const receipt = await (await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: secondReward })).wait()
+            const gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+
+            const request = await autoClaim.claimRequests(signers[1].address, poolCommitter.address)
+
+            const balanceAfter = await ethers.provider.getBalance(signers[1].address)
+
+            expect(request.reward).to.equal(secondReward)
+            expect(request.updateIntervalId).to.equal(await poolCommitter.updateIntervalId())
+
+            // Got paid reward. Paid reward - 50 plus gas on second commit
+            expect(balanceAfter.sub(balanceBefore).add(gasCost)).to.equal(reward - secondReward)
+        })
+    })
+})

--- a/test/AutoClaim/multiPaidClaimMultiplePoolCommitters.ts
+++ b/test/AutoClaim/multiPaidClaimMultiplePoolCommitters.ts
@@ -1,0 +1,123 @@
+import { ethers } from "hardhat"
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+import {
+    LeveragedPool,
+    TestToken,
+    ERC20,
+    PoolSwapLibrary,
+    PoolCommitter,
+    AutoClaim,
+    PoolKeeper,
+} from "../../types"
+
+import {
+    POOL_CODE,
+    DEFAULT_FEE,
+    LONG_MINT,
+    LONG_BURN,
+    SHORT_MINT,
+} from "../constants"
+import {
+    deployPoolAndTokenContracts,
+    getRandomInt,
+    generateRandomAddress,
+    createCommit,
+    CommitEventArgs,
+    timeout,
+    deployMockPool,
+    getEventArgs,
+} from "../utilities"
+import { BigNumber, BigNumberish } from "ethers"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const amountCommitted = ethers.utils.parseEther("2000")
+const amountMinted = ethers.utils.parseEther("10000")
+const feeAddress = generateRandomAddress()
+const lastPrice = ethers.utils.parseEther(getRandomInt(99999999, 1).toString())
+const updateInterval = 200
+const frontRunningInterval = 100 // seconds
+const fee = DEFAULT_FEE
+const leverage = 1
+const reward = ethers.utils.parseEther("103")
+
+describe("AutoClaim - paidClaim", () => {
+    let poolCommitter: PoolCommitter
+    let token: TestToken
+    let shortToken: ERC20
+    let longToken: ERC20
+    let pool: LeveragedPool
+    let library: PoolSwapLibrary
+    let autoClaim: AutoClaim
+    let signers: SignerWithAddress[]
+    let poolKeeper: PoolKeeper
+
+    const commits: CommitEventArgs[] | undefined = []
+    beforeEach(async () => {
+        const result = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee
+        )
+        pool = result.pool
+        library = result.library
+        poolCommitter = result.poolCommitter
+        autoClaim = result.autoClaim
+        signers = result.signers
+        poolKeeper = result.poolKeeper
+
+        token = result.token
+        shortToken = result.shortToken
+        longToken = result.longToken
+
+        await token.approve(pool.address, amountMinted)
+        await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+    })
+
+    context("When there is no claim", async () => {
+        it("does nothing", async () => {
+            const receipt = await (await autoClaim.paidClaim(signers[0].address, poolCommitter.address)).wait()
+            expect(receipt?.events?.length).to.equal(0)
+        })
+    })
+
+    context("When there is a claim but it is still pending", async () => {
+        it("does nothing", async () => {
+            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+            const receipt = await (await autoClaim.paidClaim(signers[0].address, poolCommitter.address)).wait()
+            expect(receipt?.events?.length).to.equal(0)
+        })
+    })
+
+    context("When there is a valid request to claim", async () => {
+        let balanceBeforeClaim: BigNumberish;
+        beforeEach(async () => {
+            await token.transfer(signers[1].address, amountCommitted.mul(2))
+            await token.connect(signers[1]).approve(pool.address, amountMinted)
+            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+            balanceBeforeClaim = await ethers.provider.getBalance(signers[0].address)
+            await autoClaim.paidClaim(signers[1].address, poolCommitter.address)
+        })
+        it("Sends money", async () => {
+            const balanceAfterClaim = await ethers.provider.getBalance(signers[0].address)
+            expect(balanceBeforeClaim).to.be.lt(balanceAfterClaim)
+        })
+        it("Deletes request", async () => {
+            const request = await autoClaim.claimRequests(signers[1].address, poolCommitter.address)
+            expect(request.updateIntervalId).to.equal(0)
+            expect(request.reward).to.equal(0)
+        })
+        it("Claims", async () => {
+            const longTokenBalance = await longToken.balanceOf(signers[1].address)
+            expect(longTokenBalance).to.equal(amountCommitted)
+        })
+    })
+
+})

--- a/test/AutoClaim/multiPaidClaimSinglePoolCommitter.ts
+++ b/test/AutoClaim/multiPaidClaimSinglePoolCommitter.ts
@@ -58,8 +58,8 @@ describe("AutoClaim - multiPaidClaimSinglePoolCommitter", () => {
     let signers: SignerWithAddress[]
     let poolKeeper: PoolKeeper
 
-    let poolCommitter2: any;
-    let pool2: any;
+    let poolCommitter2: any
+    let pool2: any
     let shortToken2: any
     let result: any
 
@@ -90,85 +90,157 @@ describe("AutoClaim - multiPaidClaimSinglePoolCommitter", () => {
 
     context("When there is no claim", async () => {
         it("does nothing", async () => {
-            const receipt = await (await autoClaim.paidClaim(signers[0].address, poolCommitter.address)).wait()
+            const receipt = await (
+                await autoClaim.paidClaim(
+                    signers[0].address,
+                    poolCommitter.address
+                )
+            ).wait()
             expect(receipt?.events?.length).to.equal(0)
         })
     })
 
     context("When there are claims, but all are still pending", async () => {
         it("does nothing", async () => {
-            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
-            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
-            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+            await createCommit(
+                poolCommitter,
+                LONG_MINT,
+                amountCommitted,
+                false,
+                true,
+                reward
+            )
+            await poolCommitter
+                .connect(signers[1])
+                .commit(LONG_MINT, amountCommitted, false, true, {
+                    value: reward,
+                })
+            await createCommit(
+                poolCommitter,
+                LONG_MINT,
+                amountCommitted,
+                false,
+                true,
+                reward
+            )
 
-            const users = [signers[0].address, signers[1].address, signers[0].address]
+            const users = [
+                signers[0].address,
+                signers[1].address,
+                signers[0].address,
+            ]
 
-            const receipt = await (await autoClaim.multiPaidClaimSinglePoolCommitter(users, poolCommitter.address)).wait()
+            const receipt = await (
+                await autoClaim.multiPaidClaimSinglePoolCommitter(
+                    users,
+                    poolCommitter.address
+                )
+            ).wait()
             expect(receipt?.events?.length).to.equal(0)
         })
     })
 
     context("When there is a valid request to claim", async () => {
-        let balanceBeforeClaim: BigNumberish;
-        let receipt;
+        let balanceBeforeClaim: BigNumberish
+        let receipt
         beforeEach(async () => {
             await token.transfer(signers[1].address, amountCommitted.mul(2))
             await token.connect(signers[1]).approve(pool.address, amountMinted)
 
-            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
+            await poolCommitter
+                .connect(signers[1])
+                .commit(LONG_MINT, amountCommitted, false, true, {
+                    value: reward,
+                })
             await timeout(updateInterval * 1000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
 
-            balanceBeforeClaim = await ethers.provider.getBalance(signers[0].address)
+            balanceBeforeClaim = await ethers.provider.getBalance(
+                signers[0].address
+            )
 
             const users = [signers[0].address, signers[1].address]
 
-            receipt = await (await autoClaim.multiPaidClaimSinglePoolCommitter(users, poolCommitter.address)).wait()
+            receipt = await (
+                await autoClaim.multiPaidClaimSinglePoolCommitter(
+                    users,
+                    poolCommitter.address
+                )
+            ).wait()
         })
         it("Sends money", async () => {
-            const balanceAfterClaim = await ethers.provider.getBalance(signers[0].address)
+            const balanceAfterClaim = await ethers.provider.getBalance(
+                signers[0].address
+            )
             expect(balanceBeforeClaim).to.be.lt(balanceAfterClaim)
         })
         it("Deletes request", async () => {
-            const request = await autoClaim.claimRequests(signers[1].address, poolCommitter.address)
+            const request = await autoClaim.claimRequests(
+                signers[1].address,
+                poolCommitter.address
+            )
             expect(request.updateIntervalId).to.equal(0)
             expect(request.reward).to.equal(0)
         })
         it("Claims", async () => {
-            const longTokenBalance = await longToken.balanceOf(signers[1].address)
+            const longTokenBalance = await longToken.balanceOf(
+                signers[1].address
+            )
             expect(longTokenBalance).to.equal(amountCommitted)
         })
     })
 
     context("When there are multiple valid requests to claim", async () => {
-        let balanceBeforeClaim: BigNumberish;
-        let receipt: Receipt;
+        let balanceBeforeClaim: BigNumberish
+        let receipt: Receipt
         beforeEach(async () => {
             await token.transfer(signers[1].address, amountCommitted.mul(2))
             await token.connect(signers[1]).approve(pool.address, amountMinted)
 
-            await poolCommitter.connect(signers[0]).commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
-            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
+            await poolCommitter
+                .connect(signers[0])
+                .commit(SHORT_MINT, amountCommitted, false, true, {
+                    value: reward,
+                })
+            await poolCommitter
+                .connect(signers[1])
+                .commit(LONG_MINT, amountCommitted, false, true, {
+                    value: reward,
+                })
             await timeout(updateInterval * 10000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
 
-            balanceBeforeClaim = await ethers.provider.getBalance(signers[0].address)
+            balanceBeforeClaim = await ethers.provider.getBalance(
+                signers[0].address
+            )
 
             const users = [signers[0].address, signers[1].address]
 
-            receipt = await (await autoClaim.multiPaidClaimSinglePoolCommitter(users, poolCommitter.address)).wait()
+            receipt = await (
+                await autoClaim.multiPaidClaimSinglePoolCommitter(
+                    users,
+                    poolCommitter.address
+                )
+            ).wait()
         })
         it("Sends money", async () => {
-            const balanceAfterClaim = await ethers.provider.getBalance(signers[0].address)
+            const balanceAfterClaim = await ethers.provider.getBalance(
+                signers[0].address
+            )
             expect(balanceBeforeClaim).to.be.lt(balanceAfterClaim)
         })
         it("Deletes request", async () => {
-            const request = await autoClaim.claimRequests(signers[1].address, poolCommitter.address)
+            const request = await autoClaim.claimRequests(
+                signers[1].address,
+                poolCommitter.address
+            )
             expect(request.updateIntervalId).to.equal(0)
             expect(request.reward).to.equal(0)
         })
         it("Claims", async () => {
-            const longTokenBalance = await longToken.balanceOf(signers[1].address)
+            const longTokenBalance = await longToken.balanceOf(
+                signers[1].address
+            )
             expect(longTokenBalance).to.equal(amountCommitted)
         })
         it("Claims the right amount of requests", async () => {
@@ -190,51 +262,87 @@ describe("AutoClaim - multiPaidClaimSinglePoolCommitter", () => {
         })
     })
 
-    context("When there are valid requests to claim, from multiple different pool committers", async () => {
-        it("should only claim for requests from the given poolCommitter", async () => {
-            // Deploy second pool
-            // deploy the pool using the factory, not separately
-            const deployParams = {
-                poolName: POOL_CODE_2,
-                frontRunningInterval: frontRunningInterval,
-                updateInterval: updateInterval,
-                leverageAmount: leverage + 1, // Change to make unique
-                quoteToken: token.address,
-                oracleWrapper: result.oracleWrapper.address,
-                settlementEthOracle: result.settlementEthOracle.address,
-                invariantCheckContract: result.invariantCheck.address,
-            }
+    context(
+        "When there are valid requests to claim, from multiple different pool committers",
+        async () => {
+            it("should only claim for requests from the given poolCommitter", async () => {
+                // Deploy second pool
+                // deploy the pool using the factory, not separately
+                const deployParams = {
+                    poolName: POOL_CODE_2,
+                    frontRunningInterval: frontRunningInterval,
+                    updateInterval: updateInterval,
+                    leverageAmount: leverage + 1, // Change to make unique
+                    quoteToken: token.address,
+                    oracleWrapper: result.oracleWrapper.address,
+                    settlementEthOracle: result.settlementEthOracle.address,
+                    invariantCheckContract: result.invariantCheck.address,
+                }
 
-            await result.factory.deployPool(deployParams)
+                await result.factory.deployPool(deployParams)
 
-            const poolAddress = await result.factory.pools(1)
-            pool2 = await ethers.getContractAt("LeveragedPool", poolAddress)
+                const poolAddress = await result.factory.pools(1)
+                pool2 = await ethers.getContractAt("LeveragedPool", poolAddress)
 
-            let commiter = await pool2.poolCommitter()
-            poolCommitter2 = await ethers.getContractAt("PoolCommitter", commiter)
+                let commiter = await pool2.poolCommitter()
+                poolCommitter2 = await ethers.getContractAt(
+                    "PoolCommitter",
+                    commiter
+                )
 
-            let shortTokenAddr = await pool.tokens(1)
-            shortToken2 = await ethers.getContractAt(ERC20Abi, shortTokenAddr)
+                let shortTokenAddr = await pool.tokens(1)
+                shortToken2 = await ethers.getContractAt(
+                    ERC20Abi,
+                    shortTokenAddr
+                )
 
-            await token.approve(pool2.address, amountMinted)
+                await token.approve(pool2.address, amountMinted)
 
-            await token.transfer(signers[1].address, amountCommitted.mul(2))
-            await token.connect(signers[1]).approve(pool.address, amountMinted)
+                await token.transfer(signers[1].address, amountCommitted.mul(2))
+                await token
+                    .connect(signers[1])
+                    .approve(pool.address, amountMinted)
 
-            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
-            await poolCommitter2.connect(signers[0]).commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
-            await timeout(updateInterval * 1000)
-            await poolKeeper.performUpkeepMultiplePools([pool.address, pool2.address])
+                await poolCommitter
+                    .connect(signers[1])
+                    .commit(LONG_MINT, amountCommitted, false, true, {
+                        value: reward,
+                    })
+                await poolCommitter2
+                    .connect(signers[0])
+                    .commit(SHORT_MINT, amountCommitted, false, true, {
+                        value: reward,
+                    })
+                await poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    true,
+                    { value: reward }
+                )
+                await timeout(updateInterval * 1000)
+                await poolKeeper.performUpkeepMultiplePools([
+                    pool.address,
+                    pool2.address,
+                ])
 
-            const users = [signers[0].address, signers[1].address]
+                const users = [signers[0].address, signers[1].address]
 
-            await (await autoClaim.multiPaidClaimSinglePoolCommitter(users, poolCommitter.address)).wait()
+                await (
+                    await autoClaim.multiPaidClaimSinglePoolCommitter(
+                        users,
+                        poolCommitter.address
+                    )
+                ).wait()
 
-            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter2.address)
-            expect(request.updateIntervalId).to.equal((await poolCommitter2.updateIntervalId()) - 1)
-        })
-
-    })
-
+                const request = await autoClaim.claimRequests(
+                    signers[0].address,
+                    poolCommitter2.address
+                )
+                expect(request.updateIntervalId).to.equal(
+                    (await poolCommitter2.updateIntervalId()) - 1
+                )
+            })
+        }
+    )
 })

--- a/test/AutoClaim/paidClaim.spec.ts
+++ b/test/AutoClaim/paidClaim.spec.ts
@@ -76,7 +76,6 @@ describe("AutoClaim - paidClaim", () => {
         longToken = result.longToken
 
         await token.approve(pool.address, amountMinted)
-        await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
     })
 
     context("When there is no claim", async () => {

--- a/test/AutoClaim/paidClaim.spec.ts
+++ b/test/AutoClaim/paidClaim.spec.ts
@@ -1,0 +1,123 @@
+import { ethers } from "hardhat"
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+import {
+    LeveragedPool,
+    TestToken,
+    ERC20,
+    PoolSwapLibrary,
+    PoolCommitter,
+    AutoClaim,
+    PoolKeeper,
+} from "../../types"
+
+import {
+    POOL_CODE,
+    DEFAULT_FEE,
+    LONG_MINT,
+    LONG_BURN,
+    SHORT_MINT,
+} from "../constants"
+import {
+    deployPoolAndTokenContracts,
+    getRandomInt,
+    generateRandomAddress,
+    createCommit,
+    CommitEventArgs,
+    timeout,
+    deployMockPool,
+    getEventArgs,
+} from "../utilities"
+import { BigNumber, BigNumberish } from "ethers"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const amountCommitted = ethers.utils.parseEther("2000")
+const amountMinted = ethers.utils.parseEther("10000")
+const feeAddress = generateRandomAddress()
+const lastPrice = ethers.utils.parseEther(getRandomInt(99999999, 1).toString())
+const updateInterval = 200
+const frontRunningInterval = 100 // seconds
+const fee = DEFAULT_FEE
+const leverage = 1
+const reward = ethers.utils.parseEther("103")
+
+describe("AutoClaim - paidClaim", () => {
+    let poolCommitter: PoolCommitter
+    let token: TestToken
+    let shortToken: ERC20
+    let longToken: ERC20
+    let pool: LeveragedPool
+    let library: PoolSwapLibrary
+    let autoClaim: AutoClaim
+    let signers: SignerWithAddress[]
+    let poolKeeper: PoolKeeper
+
+    const commits: CommitEventArgs[] | undefined = []
+    beforeEach(async () => {
+        const result = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee
+        )
+        pool = result.pool
+        library = result.library
+        poolCommitter = result.poolCommitter
+        autoClaim = result.autoClaim
+        signers = result.signers
+        poolKeeper = result.poolKeeper
+
+        token = result.token
+        shortToken = result.shortToken
+        longToken = result.longToken
+
+        await token.approve(pool.address, amountMinted)
+        await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+    })
+
+    context("When there is no claim", async () => {
+        it("does nothing", async () => {
+            const receipt = await (await autoClaim.paidClaim(signers[0].address, poolCommitter.address)).wait()
+            expect(receipt?.events?.length).to.equal(0)
+        })
+    })
+
+    context("When there is a claim but it is still pending", async () => {
+        it("does nothing", async () => {
+            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
+            const receipt = await (await autoClaim.paidClaim(signers[0].address, poolCommitter.address)).wait()
+            expect(receipt?.events?.length).to.equal(0)
+        })
+    })
+
+    context("When there is a valid request to claim", async () => {
+        let balanceBeforeClaim: BigNumberish;
+        beforeEach(async () => {
+            await token.transfer(signers[1].address, amountCommitted.mul(2))
+            await token.connect(signers[1]).approve(pool.address, amountMinted)
+            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+            balanceBeforeClaim = await ethers.provider.getBalance(signers[0].address)
+            await autoClaim.paidClaim(signers[1].address, poolCommitter.address)
+        })
+        it("Sends money", async () => {
+            const balanceAfterClaim = await ethers.provider.getBalance(signers[0].address)
+            expect(balanceBeforeClaim).to.be.lt(balanceAfterClaim)
+        })
+        it("Deletes request", async () => {
+            const request = await autoClaim.claimRequests(signers[1].address, poolCommitter.address)
+            expect(request.updateIntervalId).to.equal(0)
+            expect(request.reward).to.equal(0)
+        })
+        it("Claims", async () => {
+            const longTokenBalance = await longToken.balanceOf(signers[1].address)
+            expect(longTokenBalance).to.equal(amountCommitted)
+        })
+    })
+
+})

--- a/test/AutoClaim/paidClaim.spec.ts
+++ b/test/AutoClaim/paidClaim.spec.ts
@@ -80,43 +80,72 @@ describe("AutoClaim - paidClaim", () => {
 
     context("When there is no claim", async () => {
         it("does nothing", async () => {
-            const receipt = await (await autoClaim.paidClaim(signers[0].address, poolCommitter.address)).wait()
+            const receipt = await (
+                await autoClaim.paidClaim(
+                    signers[0].address,
+                    poolCommitter.address
+                )
+            ).wait()
             expect(receipt?.events?.length).to.equal(0)
         })
     })
 
     context("When there is a claim but it is still pending", async () => {
         it("does nothing", async () => {
-            await createCommit(poolCommitter, LONG_MINT, amountCommitted, false, true, reward)
-            const receipt = await (await autoClaim.paidClaim(signers[0].address, poolCommitter.address)).wait()
+            await createCommit(
+                poolCommitter,
+                LONG_MINT,
+                amountCommitted,
+                false,
+                true,
+                reward
+            )
+            const receipt = await (
+                await autoClaim.paidClaim(
+                    signers[0].address,
+                    poolCommitter.address
+                )
+            ).wait()
             expect(receipt?.events?.length).to.equal(0)
         })
     })
 
     context("When there is a valid request to claim", async () => {
-        let balanceBeforeClaim: BigNumberish;
+        let balanceBeforeClaim: BigNumberish
         beforeEach(async () => {
             await token.transfer(signers[1].address, amountCommitted.mul(2))
             await token.connect(signers[1]).approve(pool.address, amountMinted)
-            await poolCommitter.connect(signers[1]).commit(LONG_MINT, amountCommitted, false, true, { value: reward })
+            await poolCommitter
+                .connect(signers[1])
+                .commit(LONG_MINT, amountCommitted, false, true, {
+                    value: reward,
+                })
             await timeout(updateInterval * 1000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
-            balanceBeforeClaim = await ethers.provider.getBalance(signers[0].address)
+            balanceBeforeClaim = await ethers.provider.getBalance(
+                signers[0].address
+            )
             await autoClaim.paidClaim(signers[1].address, poolCommitter.address)
         })
         it("Sends money", async () => {
-            const balanceAfterClaim = await ethers.provider.getBalance(signers[0].address)
+            const balanceAfterClaim = await ethers.provider.getBalance(
+                signers[0].address
+            )
             expect(balanceBeforeClaim).to.be.lt(balanceAfterClaim)
         })
         it("Deletes request", async () => {
-            const request = await autoClaim.claimRequests(signers[1].address, poolCommitter.address)
+            const request = await autoClaim.claimRequests(
+                signers[1].address,
+                poolCommitter.address
+            )
             expect(request.updateIntervalId).to.equal(0)
             expect(request.reward).to.equal(0)
         })
         it("Claims", async () => {
-            const longTokenBalance = await longToken.balanceOf(signers[1].address)
+            const longTokenBalance = await longToken.balanceOf(
+                signers[1].address
+            )
             expect(longTokenBalance).to.equal(amountCommitted)
         })
     })
-
 })

--- a/test/AutoClaim/withdrawClaimRequest.spec.ts
+++ b/test/AutoClaim/withdrawClaimRequest.spec.ts
@@ -1,0 +1,183 @@
+import { ethers } from "hardhat"
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+import {
+    LeveragedPool,
+    TestToken,
+    ERC20,
+    PoolSwapLibrary,
+    PoolCommitter,
+    AutoClaim,
+    PoolKeeper,
+} from "../../types"
+
+import {
+    POOL_CODE,
+    DEFAULT_FEE,
+    LONG_MINT,
+    LONG_BURN,
+    SHORT_MINT,
+    POOL_CODE_2,
+} from "../constants"
+import {
+    deployPoolAndTokenContracts,
+    getRandomInt,
+    generateRandomAddress,
+    createCommit,
+    CommitEventArgs,
+    timeout,
+    deployMockPool,
+    getEventArgs,
+} from "../utilities"
+import { BigNumber, BigNumberish, ContractReceipt } from "ethers"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { Receipt } from "hardhat-deploy/dist/types"
+import { TransactionTypes } from "@ethersproject/transactions"
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const amountCommitted = ethers.utils.parseEther("2000")
+const amountMinted = ethers.utils.parseEther("10000")
+const feeAddress = generateRandomAddress()
+const lastPrice = ethers.utils.parseEther(getRandomInt(99999999, 1).toString())
+const updateInterval = 200
+const frontRunningInterval = 100 // seconds
+const fee = DEFAULT_FEE
+const leverage = 1
+const reward = ethers.utils.parseEther("100")
+
+describe("AutoClaim - withdrawClaimRequest", () => {
+    let poolCommitter: PoolCommitter
+    let token: TestToken
+    let shortToken: ERC20
+    let longToken: ERC20
+    let pool: LeveragedPool
+    let library: PoolSwapLibrary
+    let autoClaim: AutoClaim
+    let signers: SignerWithAddress[]
+    let poolKeeper: PoolKeeper
+    let result: any
+
+    const commits: CommitEventArgs[] | undefined = []
+    beforeEach(async () => {
+        result = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee
+        )
+        pool = result.pool
+        library = result.library
+        poolCommitter = result.poolCommitter
+        autoClaim = result.autoClaim
+        signers = result.signers
+        poolKeeper = result.poolKeeper
+
+        token = result.token
+        shortToken = result.shortToken
+        longToken = result.longToken
+
+        await token.approve(pool.address, amountMinted)
+    })
+
+    context("When there are no pending requests", async () => {
+        it("does nothing", async () => {
+            const receipt = await (await autoClaim.withdrawClaimRequest(poolCommitter.address)).wait()
+            expect(receipt?.events?.length).to.equal(0)
+        })
+    })
+    context("When there is a pending request that is not ready to be claimed", async () => {
+        let balanceBefore: BigNumberish;
+        beforeEach(async () => {
+            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
+            balanceBefore = await ethers.provider.getBalance(signers[0].address)
+            await autoClaim.withdrawClaimRequest(poolCommitter.address)
+        })
+        it("Sends money back", async () => {
+            const balanceAfter = await ethers.provider.getBalance(signers[0].address)
+            expect(balanceAfter).to.be.gt(balanceBefore)
+        })
+        it("Deletes request", async () => {
+            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
+            expect(request.updateIntervalId).to.equal(0)
+            expect(request.reward).to.equal(0)
+        })
+    })
+    context("When there are multiple pending claim requests on a single pool Committer", async () => {
+        let balanceBefore: BigNumber;
+        let receipt: ContractReceipt
+        beforeEach(async () => {
+            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
+            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+            balanceBefore = await ethers.provider.getBalance(signers[0].address)
+            receipt = await (await autoClaim.withdrawClaimRequest(poolCommitter.address)).wait()
+        })
+        it("Sends all money back", async () => {
+            const gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+            const balanceAfter = await ethers.provider.getBalance(signers[0].address)
+            expect(balanceAfter).to.eq(balanceBefore.add(reward.mul(2)).sub(gasCost))
+        })
+        it("Deletes request", async () => {
+            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
+            expect(request.updateIntervalId).to.equal(0)
+            expect(request.reward).to.equal(0)
+        })
+    })
+    context("When there are multiple pending claim requests across multiple pool Committers", async () => {
+        let balanceBefore: BigNumber;
+        let pool2: any
+        let poolCommitter2: any
+        let receipt: ContractReceipt
+        beforeEach(async () => {
+            // Deploy second pool
+            // deploy the pool using the factory, not separately
+            const deployParams = {
+                poolName: POOL_CODE_2,
+                frontRunningInterval: frontRunningInterval,
+                updateInterval: updateInterval,
+                leverageAmount: leverage + 1, // Change to make unique
+                quoteToken: token.address,
+                oracleWrapper: result.oracleWrapper.address,
+                settlementEthOracle: result.settlementEthOracle.address,
+                invariantCheckContract: result.invariantCheck.address,
+            }
+
+            await result.factory.deployPool(deployParams)
+
+            const poolAddress = await result.factory.pools(1)
+            pool2 = await ethers.getContractAt("LeveragedPool", poolAddress)
+
+            let commiter = await pool2.poolCommitter()
+            poolCommitter2 = await ethers.getContractAt("PoolCommitter", commiter)
+
+            await token.approve(pool2.address, amountMinted)
+
+            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
+            await poolCommitter2.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
+
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepMultiplePools([pool.address, pool2.address])
+            balanceBefore = await ethers.provider.getBalance(signers[0].address)
+            receipt = await (await autoClaim.withdrawClaimRequest(poolCommitter.address)).wait()
+        })
+        it("Sends the right amount of money back", async () => {
+            const gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+            const balanceAfter = await ethers.provider.getBalance(signers[0].address)
+            expect(balanceAfter).to.eq(balanceBefore.add(reward).sub(gasCost))
+        })
+        it("Deletes request", async () => {
+            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
+            expect(request.updateIntervalId).to.equal(0)
+            expect(request.reward).to.equal(0)
+        })
+        it("Keeps the one that was not withdrawn", async () => {
+            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter2.address)
+            expect(request.updateIntervalId).to.equal((await poolCommitter2.updateIntervalId()).sub(1))
+            expect(request.reward).to.equal(reward)
+        })
+    })
+})

--- a/test/AutoClaim/withdrawClaimRequest.spec.ts
+++ b/test/AutoClaim/withdrawClaimRequest.spec.ts
@@ -84,100 +84,181 @@ describe("AutoClaim - withdrawClaimRequest", () => {
 
     context("When there are no pending requests", async () => {
         it("does nothing", async () => {
-            const receipt = await (await autoClaim.withdrawClaimRequest(poolCommitter.address)).wait()
+            const receipt = await (
+                await autoClaim.withdrawClaimRequest(poolCommitter.address)
+            ).wait()
             expect(receipt?.events?.length).to.equal(0)
         })
     })
-    context("When there is a pending request that is not ready to be claimed", async () => {
-        let balanceBefore: BigNumberish;
-        beforeEach(async () => {
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
-            balanceBefore = await ethers.provider.getBalance(signers[0].address)
-            await autoClaim.withdrawClaimRequest(poolCommitter.address)
-        })
-        it("Sends money back", async () => {
-            const balanceAfter = await ethers.provider.getBalance(signers[0].address)
-            expect(balanceAfter).to.be.gt(balanceBefore)
-        })
-        it("Deletes request", async () => {
-            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
-            expect(request.updateIntervalId).to.equal(0)
-            expect(request.reward).to.equal(0)
-        })
-    })
-    context("When there are multiple pending claim requests on a single pool Committer", async () => {
-        let balanceBefore: BigNumber;
-        let receipt: ContractReceipt
-        beforeEach(async () => {
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
-            await timeout(updateInterval * 1000)
-            await poolKeeper.performUpkeepSinglePool(pool.address)
-            balanceBefore = await ethers.provider.getBalance(signers[0].address)
-            receipt = await (await autoClaim.withdrawClaimRequest(poolCommitter.address)).wait()
-        })
-        it("Sends all money back", async () => {
-            const gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice)
-            const balanceAfter = await ethers.provider.getBalance(signers[0].address)
-            expect(balanceAfter).to.eq(balanceBefore.add(reward.mul(2)).sub(gasCost))
-        })
-        it("Deletes request", async () => {
-            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
-            expect(request.updateIntervalId).to.equal(0)
-            expect(request.reward).to.equal(0)
-        })
-    })
-    context("When there are multiple pending claim requests across multiple pool Committers", async () => {
-        let balanceBefore: BigNumber;
-        let pool2: any
-        let poolCommitter2: any
-        let receipt: ContractReceipt
-        beforeEach(async () => {
-            // Deploy second pool
-            // deploy the pool using the factory, not separately
-            const deployParams = {
-                poolName: POOL_CODE_2,
-                frontRunningInterval: frontRunningInterval,
-                updateInterval: updateInterval,
-                leverageAmount: leverage + 1, // Change to make unique
-                quoteToken: token.address,
-                oracleWrapper: result.oracleWrapper.address,
-                settlementEthOracle: result.settlementEthOracle.address,
-                invariantCheckContract: result.invariantCheck.address,
-            }
+    context(
+        "When there is a pending request that is not ready to be claimed",
+        async () => {
+            let balanceBefore: BigNumberish
+            beforeEach(async () => {
+                await poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    true,
+                    { value: reward }
+                )
+                balanceBefore = await ethers.provider.getBalance(
+                    signers[0].address
+                )
+                await autoClaim.withdrawClaimRequest(poolCommitter.address)
+            })
+            it("Sends money back", async () => {
+                const balanceAfter = await ethers.provider.getBalance(
+                    signers[0].address
+                )
+                expect(balanceAfter).to.be.gt(balanceBefore)
+            })
+            it("Deletes request", async () => {
+                const request = await autoClaim.claimRequests(
+                    signers[0].address,
+                    poolCommitter.address
+                )
+                expect(request.updateIntervalId).to.equal(0)
+                expect(request.reward).to.equal(0)
+            })
+        }
+    )
+    context(
+        "When there are multiple pending claim requests on a single pool Committer",
+        async () => {
+            let balanceBefore: BigNumber
+            let receipt: ContractReceipt
+            beforeEach(async () => {
+                await poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    true,
+                    { value: reward }
+                )
+                await poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    true,
+                    { value: reward }
+                )
+                await timeout(updateInterval * 1000)
+                await poolKeeper.performUpkeepSinglePool(pool.address)
+                balanceBefore = await ethers.provider.getBalance(
+                    signers[0].address
+                )
+                receipt = await (
+                    await autoClaim.withdrawClaimRequest(poolCommitter.address)
+                ).wait()
+            })
+            it("Sends all money back", async () => {
+                const gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+                const balanceAfter = await ethers.provider.getBalance(
+                    signers[0].address
+                )
+                expect(balanceAfter).to.eq(
+                    balanceBefore.add(reward.mul(2)).sub(gasCost)
+                )
+            })
+            it("Deletes request", async () => {
+                const request = await autoClaim.claimRequests(
+                    signers[0].address,
+                    poolCommitter.address
+                )
+                expect(request.updateIntervalId).to.equal(0)
+                expect(request.reward).to.equal(0)
+            })
+        }
+    )
+    context(
+        "When there are multiple pending claim requests across multiple pool Committers",
+        async () => {
+            let balanceBefore: BigNumber
+            let pool2: any
+            let poolCommitter2: any
+            let receipt: ContractReceipt
+            beforeEach(async () => {
+                // Deploy second pool
+                // deploy the pool using the factory, not separately
+                const deployParams = {
+                    poolName: POOL_CODE_2,
+                    frontRunningInterval: frontRunningInterval,
+                    updateInterval: updateInterval,
+                    leverageAmount: leverage + 1, // Change to make unique
+                    quoteToken: token.address,
+                    oracleWrapper: result.oracleWrapper.address,
+                    settlementEthOracle: result.settlementEthOracle.address,
+                    invariantCheckContract: result.invariantCheck.address,
+                }
 
-            await result.factory.deployPool(deployParams)
+                await result.factory.deployPool(deployParams)
 
-            const poolAddress = await result.factory.pools(1)
-            pool2 = await ethers.getContractAt("LeveragedPool", poolAddress)
+                const poolAddress = await result.factory.pools(1)
+                pool2 = await ethers.getContractAt("LeveragedPool", poolAddress)
 
-            let commiter = await pool2.poolCommitter()
-            poolCommitter2 = await ethers.getContractAt("PoolCommitter", commiter)
+                let commiter = await pool2.poolCommitter()
+                poolCommitter2 = await ethers.getContractAt(
+                    "PoolCommitter",
+                    commiter
+                )
 
-            await token.approve(pool2.address, amountMinted)
+                await token.approve(pool2.address, amountMinted)
 
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
-            await poolCommitter2.commit(SHORT_MINT, amountCommitted, false, true, { value: reward })
+                await poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    true,
+                    { value: reward }
+                )
+                await poolCommitter2.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    true,
+                    { value: reward }
+                )
 
-            await timeout(updateInterval * 1000)
-            await poolKeeper.performUpkeepMultiplePools([pool.address, pool2.address])
-            balanceBefore = await ethers.provider.getBalance(signers[0].address)
-            receipt = await (await autoClaim.withdrawClaimRequest(poolCommitter.address)).wait()
-        })
-        it("Sends the right amount of money back", async () => {
-            const gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice)
-            const balanceAfter = await ethers.provider.getBalance(signers[0].address)
-            expect(balanceAfter).to.eq(balanceBefore.add(reward).sub(gasCost))
-        })
-        it("Deletes request", async () => {
-            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter.address)
-            expect(request.updateIntervalId).to.equal(0)
-            expect(request.reward).to.equal(0)
-        })
-        it("Keeps the one that was not withdrawn", async () => {
-            const request = await autoClaim.claimRequests(signers[0].address, poolCommitter2.address)
-            expect(request.updateIntervalId).to.equal((await poolCommitter2.updateIntervalId()).sub(1))
-            expect(request.reward).to.equal(reward)
-        })
-    })
+                await timeout(updateInterval * 1000)
+                await poolKeeper.performUpkeepMultiplePools([
+                    pool.address,
+                    pool2.address,
+                ])
+                balanceBefore = await ethers.provider.getBalance(
+                    signers[0].address
+                )
+                receipt = await (
+                    await autoClaim.withdrawClaimRequest(poolCommitter.address)
+                ).wait()
+            })
+            it("Sends the right amount of money back", async () => {
+                const gasCost = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+                const balanceAfter = await ethers.provider.getBalance(
+                    signers[0].address
+                )
+                expect(balanceAfter).to.eq(
+                    balanceBefore.add(reward).sub(gasCost)
+                )
+            })
+            it("Deletes request", async () => {
+                const request = await autoClaim.claimRequests(
+                    signers[0].address,
+                    poolCommitter.address
+                )
+                expect(request.updateIntervalId).to.equal(0)
+                expect(request.reward).to.equal(0)
+            })
+            it("Keeps the one that was not withdrawn", async () => {
+                const request = await autoClaim.claimRequests(
+                    signers[0].address,
+                    poolCommitter2.address
+                )
+                expect(request.updateIntervalId).to.equal(
+                    (await poolCommitter2.updateIntervalId()).sub(1)
+                )
+                expect(request.reward).to.equal(reward)
+            })
+        }
+    )
 })

--- a/test/LeveragedPool/initialize.spec.ts
+++ b/test/LeveragedPool/initialize.spec.ts
@@ -188,7 +188,8 @@ describe("LeveragedPool - initialize", () => {
             const poolCommitter = await (
                 await poolCommitterFactory.deploy(
                     setupContracts.factory.address,
-                    setupContracts.invariantCheck.address
+                    setupContracts.invariantCheck.address,
+                    setupContracts.autoClaim.address
                 )
             ).deployed()
 

--- a/test/LeveragedPool/initialize.spec.ts
+++ b/test/LeveragedPool/initialize.spec.ts
@@ -12,6 +12,7 @@ import {
     ChainlinkOracleWrapper,
     PoolCommitter__factory,
     PoolCommitter,
+    AutoClaim__factory,
 } from "../../types"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import {
@@ -185,7 +186,8 @@ describe("LeveragedPool - initialize", () => {
 
             const poolCommitter = await (
                 await poolCommitterFactory.deploy(
-                    setupContracts.factory.address
+                    setupContracts.factory.address,
+                    generateRandomAddress()
                 )
             ).deployed()
 

--- a/test/LeveragedPool/poolUpkeep.spec.ts
+++ b/test/LeveragedPool/poolUpkeep.spec.ts
@@ -143,7 +143,7 @@ describe("LeveragedPool - executeAllCommitments", async () => {
             )
             await result.pool.setKeeper(result.signers[0].address)
             await result.token.approve(result.pool.address, 10000)
-            await result.poolCommitter.commit(LONG_MINT, 1000, false)
+            await result.poolCommitter.commit(LONG_MINT, 1000, false, false)
             await result.pool.drainPool(10)
             await result.invariantCheck.checkInvariants(result.pool.address)
             await expect(

--- a/test/LeveragedPool/transferFees.spec.ts
+++ b/test/LeveragedPool/transferFees.spec.ts
@@ -135,13 +135,13 @@ describe("LeveragedPool - feeTransfer", async () => {
             pool = result.pool
             poolCommitter = result.poolCommitter
             await result.token.approve(result.pool.address, 10000)
-            await result.poolCommitter.commit(LONG_MINT, 1000, false)
+            await result.poolCommitter.commit(LONG_MINT, 1000, false, false)
             await result.pool.drainPool(10)
             await result.invariantCheck.checkInvariants(result.pool.address)
         })
         it("Commit should be paused", async () => {
             await expect(
-                poolCommitter.commit(LONG_BURN, 123, false)
+                poolCommitter.commit(LONG_BURN, 123, false, false)
             ).to.revertedWith("Pool is paused")
         })
         it("Update fee address", async () => {

--- a/test/LeveragedPool/transferFees.spec.ts
+++ b/test/LeveragedPool/transferFees.spec.ts
@@ -120,7 +120,7 @@ describe("LeveragedPool - feeTransfer", () => {
         })
     })
 
-    context("Test Paused Pools cannot transfer tokens", async () => {
+    context.skip("Test Paused Pools cannot transfer tokens", async () => {
         beforeEach(async () => {
             await pool.pause()
         })

--- a/test/PoolCommitter/burningFee.spec.ts
+++ b/test/PoolCommitter/burningFee.spec.ts
@@ -76,10 +76,20 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             shortToken = result.shortToken
             await poolKeeper.setGasPrice("0")
             await token.approve(pool.address, amountCommitted)
-            await await poolCommitter.commit(SHORT_MINT, amountCommitted, false, false)
+            await await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
-            await await poolCommitter.commit(SHORT_BURN, amountCommitted, true, false)
+            await await poolCommitter.commit(
+                SHORT_BURN,
+                amountCommitted,
+                true,
+                false
+            )
         })
         it("burns all pool tokens", async () => {
             expect(await shortToken.totalSupply()).to.equal(0)
@@ -150,10 +160,20 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             longToken = result.longToken
             await poolKeeper.setGasPrice("0")
             await token.approve(pool.address, amountCommitted)
-            await await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
+            await await poolCommitter.commit(
+                LONG_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
-            await await poolCommitter.commit(LONG_BURN, amountCommitted, true, false)
+            await await poolCommitter.commit(
+                LONG_BURN,
+                amountCommitted,
+                true,
+                false
+            )
         })
         it("burns all pool tokens", async () => {
             expect(await longToken.totalSupply()).to.equal(0)

--- a/test/PoolCommitter/commit.spec.ts
+++ b/test/PoolCommitter/commit.spec.ts
@@ -71,7 +71,12 @@ describe("LeveragedPool - commit", () => {
             poolKeeper = result.poolKeeper
             await token.approve(pool.address, amountCommitted)
             receipt = await (
-                await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+                await poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    false
+                )
             ).wait()
         })
         it("should update the total commit amount", async () => {
@@ -111,14 +116,19 @@ describe("LeveragedPool - commit", () => {
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).shortMintAmount
             ).to.eq(0)
-            await poolCommitter.commit([0], amountCommitted, false)
+            await poolCommitter.commit([0], amountCommitted, false, false)
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).shortMintAmount
             ).to.eq(amountCommitted)
         })
 
         it("should update the shadow short burn balance for short burn commits", async () => {
-            await await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.setKeeper(signers[0].address)
             await pool.poolUpkeep(1, 2)
@@ -128,7 +138,12 @@ describe("LeveragedPool - commit", () => {
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).shortBurnAmount
             ).to.eq(0)
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_BURN,
+                amountCommitted,
+                false,
+                false
+            )
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).shortBurnAmount
             ).to.eq(amountCommitted)
@@ -138,7 +153,7 @@ describe("LeveragedPool - commit", () => {
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).longMintAmount
             ).to.eq(0)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
 
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).longMintAmount
@@ -146,7 +161,7 @@ describe("LeveragedPool - commit", () => {
         })
 
         it("should update the shadow long burn balance for long burn commits", async () => {
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.setKeeper(signers[0].address)
             await pool.poolUpkeep(1, 2)
@@ -156,7 +171,7 @@ describe("LeveragedPool - commit", () => {
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).longBurnAmount
             ).to.eq(0)
-            await poolCommitter.commit(LONG_BURN, amountCommitted, false)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, false, false)
             expect(
                 (await getCurrentTotalCommit(poolCommitter)).longBurnAmount
             ).to.eq(amountCommitted)
@@ -183,7 +198,12 @@ describe("LeveragedPool - commit", () => {
 
             await token.approve(pool.address, amountCommitted.mul(999))
             await pool.setKeeper(signers[0].address)
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
         })
@@ -191,7 +211,7 @@ describe("LeveragedPool - commit", () => {
         it("Should appropriately set values", async () => {
             // Commit using the balance in the contracts, which we just committed.
             const shortTokenSupplyBefore = await shortToken.totalSupply()
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, true)
+            await poolCommitter.commit(SHORT_BURN, amountCommitted, true, false)
             const shortTokenSupplyAfter = await shortToken.totalSupply()
 
             const userMostRecentCommit = await getCurrentUserCommit(
@@ -218,15 +238,20 @@ describe("LeveragedPool - commit", () => {
         })
 
         it("Should not allow for too many commitments (that bring amount over a user's balance)", async () => {
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, true)
+            await poolCommitter.commit(SHORT_BURN, amountCommitted, true, false)
             await expect(
-                poolCommitter.commit(SHORT_BURN, amountCommitted, true)
+                poolCommitter.commit(SHORT_BURN, amountCommitted, true, false)
             ).to.be.revertedWith("Insufficient pool tokens")
         })
 
         it("Should not allow commits that are too large", async () => {
             await expect(
-                poolCommitter.commit(SHORT_BURN, amountCommitted.mul(300), true)
+                poolCommitter.commit(
+                    SHORT_BURN,
+                    amountCommitted.mul(300),
+                    true,
+                    false
+                )
             ).to.be.revertedWith("Insufficient pool tokens")
         })
 
@@ -234,7 +259,12 @@ describe("LeveragedPool - commit", () => {
             await poolCommitter.claim(signers[0].address)
 
             /* SHORT_MINT COMMIT */
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             /* UPKEEP */
             await pool.poolUpkeep(1, 1)
@@ -242,7 +272,7 @@ describe("LeveragedPool - commit", () => {
             const shortTokenSupplyBefore = await shortToken.totalSupply()
 
             /* SHORT_BURN COMMIT */
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, true)
+            await poolCommitter.commit(SHORT_BURN, amountCommitted, true, false)
 
             const userCommit = await getCurrentUserCommit(
                 signers[0].address,
@@ -252,7 +282,12 @@ describe("LeveragedPool - commit", () => {
             // balanceShortBurnAmount is updated
             expect(userCommit.balanceShortBurnAmount).to.equal(amountCommitted)
             /* SHORT_BURN COMMIT */
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_BURN,
+                amountCommitted,
+                false,
+                false
+            )
 
             const shortTokenSupplyAfter = await shortToken.totalSupply()
 
@@ -313,12 +348,22 @@ describe("LeveragedPool - commit", () => {
 
             await token.approve(pool.address, amountCommitted.mul(999))
             await pool.setKeeper(signers[0].address)
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
             await poolCommitter.claim(signers[0].address)
             // Burn, so you have settlement tokens in your aggregate balance
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_BURN,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
         })
@@ -326,7 +371,7 @@ describe("LeveragedPool - commit", () => {
         it("Should appropriately set values", async () => {
             // Commit using the balance in the contracts, which we just committed.
             const shortTokenSupplyBefore = await shortToken.totalSupply()
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, true)
+            await poolCommitter.commit(SHORT_MINT, amountCommitted, true, false)
             const shortTokenSupplyAfter = await shortToken.totalSupply()
 
             const userMostRecentCommit = await getCurrentUserCommit(
@@ -353,23 +398,33 @@ describe("LeveragedPool - commit", () => {
         })
 
         it("Should not allow for too many commitments (that bring amount over a user's balance)", async () => {
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, true)
+            await poolCommitter.commit(SHORT_MINT, amountCommitted, true, false)
             await expect(
-                poolCommitter.commit(SHORT_MINT, amountCommitted, true)
+                poolCommitter.commit(SHORT_MINT, amountCommitted, true, false)
             ).be.rejected // Can't figure out how to get the "overflow" error message to be used in chai assertins
         })
 
         it("Should not allow commits that are too large", async () => {
             await expect(
-                poolCommitter.commit(SHORT_MINT, amountCommitted.mul(300), true)
+                poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted.mul(300),
+                    true,
+                    false
+                )
             ).be.rejected // Can't figure out how to get the "overflow" error message to be used in chai assertins
         })
 
         it("Should allow for a combination of short_mint commits from wallet and aggregate balance", async () => {
             const shortTokenSupplyBefore = await shortToken.totalSupply()
 
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, true)
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(SHORT_MINT, amountCommitted, true, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
 
             const shortTokenSupplyAfter = await shortToken.totalSupply()
 
@@ -428,7 +483,7 @@ describe("LeveragedPool - commit", () => {
 
             await token.approve(pool.address, amountCommitted.mul(999))
             await pool.setKeeper(signers[0].address)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
         })
@@ -436,7 +491,7 @@ describe("LeveragedPool - commit", () => {
         it("Should appropriately set values", async () => {
             // Commit using the balance in the contracts, which we just committed.
             const longTokenSupplyBefore = await longToken.totalSupply()
-            await poolCommitter.commit(LONG_BURN, amountCommitted, true)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, true, false)
             const longTokenSupplyAfter = await longToken.totalSupply()
 
             const userMostRecentCommit = await getCurrentUserCommit(
@@ -463,28 +518,33 @@ describe("LeveragedPool - commit", () => {
         })
 
         it("Should not allow for too many commitments (that bring amount over a user's balance)", async () => {
-            await poolCommitter.commit(LONG_BURN, amountCommitted, true)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, true, false)
             await expect(
-                poolCommitter.commit(LONG_BURN, amountCommitted, true)
+                poolCommitter.commit(LONG_BURN, amountCommitted, true, false)
             ).to.be.revertedWith("Insufficient pool tokens")
         })
 
         it("Should not allow commits that are too large", async () => {
             await expect(
-                poolCommitter.commit(LONG_BURN, amountCommitted.mul(300), true)
+                poolCommitter.commit(
+                    LONG_BURN,
+                    amountCommitted.mul(300),
+                    true,
+                    false
+                )
             ).to.be.revertedWith("Insufficient pool tokens")
         })
 
         it("Should allow for a combination of long_burn commits from wallet and aggregate balance", async () => {
             await poolCommitter.claim(signers[0].address)
 
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
 
             const longTokenSupplyBefore = await longToken.totalSupply()
 
-            await poolCommitter.commit(LONG_BURN, amountCommitted, true)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, true, false)
 
             const userCommit = await getCurrentUserCommit(
                 signers[0].address,
@@ -493,7 +553,7 @@ describe("LeveragedPool - commit", () => {
 
             // balanceLongBurnAmount is updated
             expect(userCommit.balanceLongBurnAmount).to.equal(amountCommitted)
-            await poolCommitter.commit(LONG_BURN, amountCommitted, false)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, false, false)
 
             const longTokenSupplyAfter = await longToken.totalSupply()
 
@@ -552,12 +612,12 @@ describe("LeveragedPool - commit", () => {
 
             await token.approve(pool.address, amountCommitted.mul(999))
             await pool.setKeeper(signers[0].address)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
             await poolCommitter.claim(signers[0].address)
             // Burn, so you have settlement tokens in your aggregate balance
-            await poolCommitter.commit(LONG_BURN, amountCommitted, false)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
         })
@@ -565,7 +625,7 @@ describe("LeveragedPool - commit", () => {
         it("Should appropriately set values", async () => {
             // Commit using the balance in the contracts, which we just committed.
             const longTokenSupplyBefore = await longToken.totalSupply()
-            await poolCommitter.commit(LONG_MINT, amountCommitted, true)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, true, false)
             const longTokenSupplyAfter = await longToken.totalSupply()
 
             const userMostRecentCommit = await getCurrentUserCommit(
@@ -591,28 +651,34 @@ describe("LeveragedPool - commit", () => {
         })
 
         it("Should not allow for too many commitments (that bring amount over a user's balance)", async () => {
-            await poolCommitter.commit(LONG_MINT, amountCommitted, true)
-            await expect(poolCommitter.commit(LONG_MINT, amountCommitted, true))
-                .be.rejected // Can't figure out how to get the "overflow" error message to be used in chai assertins
+            await poolCommitter.commit(LONG_MINT, amountCommitted, true, false)
+            await expect(
+                poolCommitter.commit(LONG_MINT, amountCommitted, true, false)
+            ).be.rejected // Can't figure out how to get the "overflow" error message to be used in chai assertins
         })
 
         it("Should not allow commits that are too large", async () => {
             await expect(
-                poolCommitter.commit(LONG_MINT, amountCommitted.mul(300), true)
+                poolCommitter.commit(
+                    LONG_MINT,
+                    amountCommitted.mul(300),
+                    true,
+                    false
+                )
             ).be.rejected // Can't figure out how to get the "overflow" error message to be used in chai assertins
         })
 
         it("Long mint from aggregate balance reduces settlement token amount in balance", async () => {
             const longTokenSupplyBefore = await longToken.totalSupply()
 
-            await poolCommitter.commit(LONG_MINT, amountCommitted, true)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, true, false)
 
             // Balance storage updates
             const settlementTokens = (
                 await poolCommitter.getAggregateBalance(signers[0].address)
             ).settlementTokens
             expect(settlementTokens).to.equal(0)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
 
             const longTokenSupplyAfter = await longToken.totalSupply()
 
@@ -647,7 +713,7 @@ describe("LeveragedPool - commit", () => {
         it("Should allow for a combination of long_mint commits from wallet and aggregate balance", async () => {
             const longTokenSupplyBefore = await longToken.totalSupply()
 
-            await poolCommitter.commit(LONG_MINT, amountCommitted, true)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, true, false)
 
             const userCommit = await getCurrentUserCommit(
                 signers[0].address,
@@ -659,7 +725,7 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.getAggregateBalance(signers[0].address)
             ).settlementTokens
             expect(settlementTokens).to.equal(0)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
 
             const longTokenSupplyAfter = await longToken.totalSupply()
 
@@ -712,12 +778,12 @@ describe("LeveragedPool - commit", () => {
 
             await token.approve(pool.address, amountCommitted.mul(999))
             await pool.setKeeper(signers[0].address)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
             await poolCommitter.claim(signers[0].address)
             // Burn, so you have settlement tokens in your aggregate balance
-            await poolCommitter.commit(LONG_BURN, amountCommitted, false)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
         })
@@ -725,10 +791,15 @@ describe("LeveragedPool - commit", () => {
         it("Operates as intended", async () => {
             const longTokenSupplyBefore = await longToken.totalSupply()
 
-            await poolCommitter.commit(LONG_MINT, amountCommitted, true)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, true, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
 
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
 
             const longTokenSupplyAfter = await longToken.totalSupply()
 
@@ -766,10 +837,15 @@ describe("LeveragedPool - commit", () => {
             const balanceBefore = await longToken.balanceOf(signers[0].address)
 
             await expect(
-                poolCommitter.commit(SHORT_BURN, amountCommitted, false)
+                poolCommitter.commit(SHORT_BURN, amountCommitted, false, false)
             ).to.be.revertedWith("ERC20: burn amount exceeds balance")
 
-            await poolCommitter.commit(SHORT_BURN, amountCommitted.div(2), true)
+            await poolCommitter.commit(
+                SHORT_BURN,
+                amountCommitted.div(2),
+                true,
+                false
+            )
 
             // Go into frontRunningInterval
             await timeout((updateInterval - frontRunningInterval / 2) * 1000)
@@ -777,7 +853,12 @@ describe("LeveragedPool - commit", () => {
             await poolCommitter.claim(signers[0].address)
 
             await expect(
-                poolCommitter.commit(SHORT_BURN, amountCommitted.div(2), true)
+                poolCommitter.commit(
+                    SHORT_BURN,
+                    amountCommitted.div(2),
+                    true,
+                    false
+                )
             ).to.be.revertedWith("Insufficient pool tokens")
 
             const longBalance = await longToken.balanceOf(signers[0].address)
@@ -814,7 +895,12 @@ describe("LeveragedPool - commit", () => {
 
                 await token.approve(pool.address, amountCommitted.mul(999))
                 await pool.setKeeper(signers[0].address)
-                await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+                await poolCommitter.commit(
+                    LONG_MINT,
+                    amountCommitted,
+                    false,
+                    false
+                )
                 await timeout(updateInterval * 1000)
                 await pool.poolUpkeep(1, 1)
             })
@@ -825,7 +911,8 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     LONG_BURN_THEN_MINT,
                     amountCommitted,
-                    true
+                    true,
+                    false
                 )
                 const longTokenSupplyAfter = await longToken.totalSupply()
 
@@ -860,13 +947,15 @@ describe("LeveragedPool - commit", () => {
                     await poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted,
-                        true
+                        true,
+                        false
                     )
                     await expect(
                         poolCommitter.commit(
                             LONG_BURN_THEN_MINT,
                             amountCommitted,
-                            true
+                            true,
+                            false
                         )
                     ).to.be.revertedWith("Insufficient pool tokens")
                 })
@@ -876,13 +965,15 @@ describe("LeveragedPool - commit", () => {
                     await poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted,
-                        true
+                        true,
+                        false
                     )
                     await expect(
                         poolCommitter.commit(
                             LONG_BURN_THEN_MINT,
                             amountCommitted,
-                            true
+                            true,
+                            false
                         )
                     ).to.be.revertedWith("Insufficient pool tokens")
                 })
@@ -893,7 +984,8 @@ describe("LeveragedPool - commit", () => {
                         poolCommitter.commit(
                             LONG_BURN_THEN_MINT,
                             amountCommitted.add(1),
-                            true
+                            true,
+                            false
                         )
                     ).to.be.revertedWith("Insufficient pool tokens")
                 })
@@ -904,7 +996,8 @@ describe("LeveragedPool - commit", () => {
                         poolCommitter.commit(
                             LONG_BURN_THEN_MINT,
                             amountCommitted.add(1),
-                            true
+                            true,
+                            false
                         )
                     ).to.be.revertedWith("Insufficient pool tokens") // The error here is different from burning from wallet, because it does not burn from user's wallet and thus needs to manually check
                 })
@@ -919,6 +1012,7 @@ describe("LeveragedPool - commit", () => {
                                 await poolCommitter.commit(
                                     SHORT_MINT,
                                     amountCommitted,
+                                    false,
                                     false
                                 )
                                 await timeout(updateInterval * 1000)
@@ -930,7 +1024,8 @@ describe("LeveragedPool - commit", () => {
                                 await poolCommitter.commit(
                                     LONG_BURN_THEN_MINT,
                                     amountCommitted,
-                                    true
+                                    true,
+                                    false
                                 )
 
                                 const balanceBefore =
@@ -964,12 +1059,14 @@ describe("LeveragedPool - commit", () => {
                     await poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted.div(2),
-                        true
+                        true,
+                        false
                     )
                     await poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted.div(2),
-                        true
+                        true,
+                        false
                     )
                     let longBalance = await pool.longBalance()
                     let shortBalance = await pool.shortBalance()
@@ -1013,7 +1110,8 @@ describe("LeveragedPool - commit", () => {
                     await poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted,
-                        true
+                        true,
+                        false
                     )
                     let longBalance = await pool.longBalance()
                     let shortBalance = await pool.shortBalance()
@@ -1092,7 +1190,7 @@ describe("LeveragedPool - commit", () => {
 
             await token.approve(pool.address, amountCommitted.mul(999))
             await pool.setKeeper(signers[0].address)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
         })
@@ -1104,6 +1202,7 @@ describe("LeveragedPool - commit", () => {
             await poolCommitter.commit(
                 LONG_BURN_THEN_MINT,
                 amountCommitted,
+                false,
                 false
             )
             const longTokenSupplyAfter = await longToken.totalSupply()
@@ -1138,12 +1237,14 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     LONG_BURN_THEN_MINT,
                     amountCommitted,
+                    false,
                     false
                 )
                 await expect(
                     poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted,
+                        false,
                         false
                     )
                 ).to.be.revertedWith("ERC20: burn amount exceeds balance")
@@ -1154,13 +1255,15 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     LONG_BURN_THEN_MINT,
                     amountCommitted,
-                    true
+                    true,
+                    false
                 )
                 await expect(
                     poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted,
-                        true
+                        true,
+                        false
                     )
                 ).to.be.revertedWith("Insufficient pool tokens")
             })
@@ -1172,6 +1275,7 @@ describe("LeveragedPool - commit", () => {
                     poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted.add(1),
+                        false,
                         false
                     )
                 ).to.be.revertedWith("ERC20: burn amount exceeds balance")
@@ -1183,7 +1287,8 @@ describe("LeveragedPool - commit", () => {
                     poolCommitter.commit(
                         LONG_BURN_THEN_MINT,
                         amountCommitted.add(1),
-                        true
+                        true,
+                        false
                     )
                 ).to.be.revertedWith("Insufficient pool tokens") // The error here is different from burning from wallet, because it does not burn from user's wallet and thus needs to manually check
             })
@@ -1196,6 +1301,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             SHORT_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
                         await timeout(updateInterval * 1000)
@@ -1208,6 +1314,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             LONG_BURN_THEN_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
 
@@ -1239,11 +1346,13 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     LONG_BURN_THEN_MINT,
                     amountCommitted.div(2),
+                    false,
                     false
                 )
                 await poolCommitter.commit(
                     LONG_BURN_THEN_MINT,
                     amountCommitted.div(2),
+                    false,
                     false
                 )
                 let longBalance = await pool.longBalance()
@@ -1289,6 +1398,7 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     LONG_BURN_THEN_MINT,
                     amountCommitted,
+                    false,
                     false
                 )
                 let longBalance = await pool.longBalance()
@@ -1350,7 +1460,12 @@ describe("LeveragedPool - commit", () => {
 
             await token.approve(pool.address, amountCommitted.mul(999))
             await pool.setKeeper(signers[0].address)
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.poolUpkeep(1, 1)
         })
@@ -1362,6 +1477,7 @@ describe("LeveragedPool - commit", () => {
             await poolCommitter.commit(
                 SHORT_BURN_THEN_MINT,
                 amountCommitted,
+                false,
                 false
             )
             const shortTokenSupplyAfter = await shortToken.totalSupply()
@@ -1396,12 +1512,14 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     SHORT_BURN_THEN_MINT,
                     amountCommitted,
+                    false,
                     false
                 )
                 await expect(
                     poolCommitter.commit(
                         SHORT_BURN_THEN_MINT,
                         amountCommitted,
+                        false,
                         false
                     )
                 ).to.be.revertedWith("ERC20: burn amount exceeds balance")
@@ -1412,13 +1530,15 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     SHORT_BURN_THEN_MINT,
                     amountCommitted,
-                    true
+                    true,
+                    false
                 )
                 await expect(
                     poolCommitter.commit(
                         SHORT_BURN_THEN_MINT,
                         amountCommitted,
-                        true
+                        true,
+                        false
                     )
                 ).to.be.revertedWith("Insufficient pool tokens")
             })
@@ -1430,6 +1550,7 @@ describe("LeveragedPool - commit", () => {
                     poolCommitter.commit(
                         SHORT_BURN_THEN_MINT,
                         amountCommitted.add(1),
+                        false,
                         false
                     )
                 ).to.be.revertedWith("ERC20: burn amount exceeds balance")
@@ -1441,7 +1562,8 @@ describe("LeveragedPool - commit", () => {
                     poolCommitter.commit(
                         SHORT_BURN_THEN_MINT,
                         amountCommitted.add(1),
-                        true
+                        true,
+                        false
                     )
                 ).to.be.revertedWith("Insufficient pool tokens") // The error here is different from burning from wallet, because it does not burn from user's wallet and thus needs to manually check
             })
@@ -1454,6 +1576,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             LONG_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
                         await timeout(updateInterval * 1000)
@@ -1466,6 +1589,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             SHORT_BURN_THEN_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
 
@@ -1498,11 +1622,13 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     SHORT_BURN_THEN_MINT,
                     amountCommitted.div(2),
+                    false,
                     false
                 )
                 await poolCommitter.commit(
                     SHORT_BURN_THEN_MINT,
                     amountCommitted.div(2),
+                    false,
                     false
                 )
                 let longBalance = await pool.longBalance()
@@ -1548,6 +1674,7 @@ describe("LeveragedPool - commit", () => {
                 await poolCommitter.commit(
                     SHORT_BURN_THEN_MINT,
                     amountCommitted,
+                    false,
                     false
                 )
                 let longBalance = await pool.longBalance()
@@ -1620,6 +1747,7 @@ describe("LeveragedPool - commit", () => {
                     await poolCommitter.commit(
                         SHORT_MINT,
                         amountCommitted,
+                        false,
                         false
                     )
 
@@ -1659,6 +1787,7 @@ describe("LeveragedPool - commit", () => {
                     await poolCommitter.commit(
                         SHORT_MINT,
                         amountCommitted,
+                        false,
                         false
                     )
 
@@ -1711,6 +1840,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             SHORT_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
 
@@ -1722,6 +1852,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             SHORT_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
 
@@ -1733,6 +1864,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             LONG_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
 
@@ -1744,12 +1876,14 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             LONG_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
                         // Commit for updateIntervalId + 8
                         await poolCommitter.commit(
                             LONG_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
 
@@ -1765,6 +1899,7 @@ describe("LeveragedPool - commit", () => {
                         await poolCommitter.commit(
                             LONG_MINT,
                             amountCommitted,
+                            false,
                             false
                         )
 
@@ -1835,6 +1970,7 @@ describe("LeveragedPool - commit", () => {
                             await poolCommitter.commit(
                                 SHORT_MINT,
                                 amountCommitted,
+                                false,
                                 false
                             )
 
@@ -1846,6 +1982,7 @@ describe("LeveragedPool - commit", () => {
                             await poolCommitter.commit(
                                 LONG_MINT,
                                 amountCommitted,
+                                false,
                                 false
                             )
 
@@ -1940,7 +2077,12 @@ describe("LeveragedPool - commit", () => {
             await token.approve(pool.address, amountCommitted)
         })
         it("should not require a quote token transfer for short burn commits", async () => {
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
 
             await timeout(updateInterval * 1000)
             await pool.setKeeper(signers[0].address)
@@ -1948,24 +2090,39 @@ describe("LeveragedPool - commit", () => {
 
             expect(await token.balanceOf(pool.address)).to.eq(amountCommitted)
             await poolCommitter.claim(signers[0].address)
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_BURN,
+                amountCommitted,
+                false,
+                false
+            )
 
             expect(await token.balanceOf(pool.address)).to.eq(amountCommitted)
         })
         it("should not require a quote token transfer for long burn commits", async () => {
-            await await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await await poolCommitter.commit(
+                LONG_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.setKeeper(signers[0].address)
             await pool.poolUpkeep(1, 2)
 
             expect(await token.balanceOf(pool.address)).to.eq(amountCommitted)
             await poolCommitter.claim(signers[0].address)
-            await poolCommitter.commit(LONG_BURN, amountCommitted, false)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, false, false)
             expect(await token.balanceOf(pool.address)).to.eq(amountCommitted)
         })
         it("should burn the user's short pair tokens for short burn commits", async () => {
             // Acquire pool tokens
-            await await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.setKeeper(signers[0].address)
             await pool.poolUpkeep(1, 2)
@@ -1976,12 +2133,22 @@ describe("LeveragedPool - commit", () => {
                 amountCommitted
             )
             await poolCommitter.claim(signers[0].address)
-            await poolCommitter.commit(SHORT_BURN, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_BURN,
+                amountCommitted,
+                false,
+                false
+            )
             expect(await shortToken.balanceOf(signers[0].address)).to.eq(0)
         })
         it("should burn the user's long pair tokens for long burn commits", async () => {
             // Acquire pool tokens
-            await await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await await poolCommitter.commit(
+                LONG_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             await timeout(updateInterval * 1000)
             await pool.setKeeper(signers[0].address)
             await pool.poolUpkeep(1, 2)
@@ -1992,18 +2159,23 @@ describe("LeveragedPool - commit", () => {
                 amountCommitted
             )
             await poolCommitter.claim(signers[0].address)
-            await poolCommitter.commit(LONG_BURN, amountCommitted, false)
+            await poolCommitter.commit(LONG_BURN, amountCommitted, false, false)
             expect(await longToken.balanceOf(signers[0].address)).to.eq(0)
         })
         it("should transfer the user's quote tokens into the pool for long mint commits", async () => {
             expect(await token.balanceOf(pool.address)).to.eq(0)
-            await poolCommitter.commit(LONG_MINT, amountCommitted, false)
+            await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
             expect(await token.balanceOf(pool.address)).to.eq(amountCommitted)
         })
 
         it("should transfer the user's quote tokens into the pool for short mint commits", async () => {
             expect(await token.balanceOf(pool.address)).to.eq(0)
-            await poolCommitter.commit(SHORT_MINT, amountCommitted, false)
+            await poolCommitter.commit(
+                SHORT_MINT,
+                amountCommitted,
+                false,
+                false
+            )
             expect(await token.balanceOf(pool.address)).to.eq(amountCommitted)
         })
     })

--- a/test/PoolCommitter/executeCommitment/baseCases.spec.ts
+++ b/test/PoolCommitter/executeCommitment/baseCases.spec.ts
@@ -60,7 +60,7 @@ describe("poolCommitter - executeCommitment: Basic test cases", () => {
             await pool.setKeeper(signers[0].address)
             // Wait until somewhere between `frontRunningInterval <-> updateInterval`
             await timeout((_updateInterval - _frontRunningInterval / 2) * 1000)
-            await committer.commit(SHORT_MINT, amountCommitted, false)
+            await committer.commit(SHORT_MINT, amountCommitted, false, false)
 
             const shortTokensSupplyBefore = await shortToken.totalSupply()
             // Now wait for updateInterval to pass

--- a/test/PoolCommitter/mintingFee.spec.ts
+++ b/test/PoolCommitter/mintingFee.spec.ts
@@ -66,7 +66,12 @@ describe("PoolCommitter - Mint commit with mint fee", () => {
             shortToken = result.shortToken
             await token.approve(pool.address, amountCommitted)
             receipt = await (
-                await poolCommitter.commit(SHORT_MINT, amountCommitted, false, false)
+                await poolCommitter.commit(
+                    SHORT_MINT,
+                    amountCommitted,
+                    false,
+                    false
+                )
             ).wait()
         })
         it("transfers all tokens to the pool", async () => {
@@ -130,7 +135,12 @@ describe("PoolCommitter - Mint commit with mint fee", () => {
             longToken = result.longToken
             await token.approve(pool.address, amountCommitted)
             receipt = await (
-                await poolCommitter.commit(LONG_MINT, amountCommitted, false, false)
+                await poolCommitter.commit(
+                    LONG_MINT,
+                    amountCommitted,
+                    false,
+                    false
+                )
             ).wait()
         })
         it("transfers all tokens to the pool", async () => {

--- a/test/PoolKeeper/checkUpkeepMultiplePools.spec.ts
+++ b/test/PoolKeeper/checkUpkeepMultiplePools.spec.ts
@@ -17,6 +17,7 @@ import {
     PoolSwapLibrary__factory,
     TestToken__factory,
     PoolFactory,
+    AutoClaim__factory,
 } from "../../types"
 
 chai.use(chaiAsPromised)
@@ -88,6 +89,13 @@ const setupHook = async () => {
     factory = await (
         await PoolFactory.deploy(generateRandomAddress())
     ).deployed()
+
+    const autoClaimFactory = (await ethers.getContractFactory("AutoClaim", {
+        signer: signers[0],
+    })) as AutoClaim__factory
+    let autoClaim = await autoClaimFactory.deploy(factory.address)
+    autoClaim = await autoClaim.deployed()
+    await factory.setAutoClaim(autoClaim.address)
 
     poolKeeper = await poolKeeperFactory.deploy(factory.address)
     await poolKeeper.deployed()

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -114,6 +114,7 @@ describe("LeveragedPool - executeAllCommitments", () => {
             await poolKeeper.performUpkeepSinglePool(pool.address)
 
             // Claim, then balance should go to account
+
             await poolCommitter.claim(signers[0].address)
             expect(await longToken.balanceOf(signers[0].address)).to.equal(
                 amountCommitted.mul(2)

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -558,6 +558,7 @@ export const createCommit = async (
         commitID: getEventArgs(receipt, "CreateCommit")?.commitID,
         amount: getEventArgs(receipt, "CreateCommit")?.amount,
         commitType: getEventArgs(receipt, "CreateCommit")?.commitType,
+        receipt: receipt
     }
 }
 

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -218,7 +218,7 @@ export const deployPoolSetupContracts = async () => {
         library,
         priceObserver,
         invariantCheck,
-        autoClaim
+        autoClaim,
     }
 }
 
@@ -331,7 +331,7 @@ export const deployPoolAndTokenContracts = async (
         oracleWrapper,
         settlementEthOracle,
         invariantCheck,
-        autoClaim
+        autoClaim,
     }
 }
 
@@ -527,7 +527,7 @@ export const deployMockPool = async (
         settlementEthOracle,
         invariantCheck,
         priceObserver,
-        autoClaim
+        autoClaim,
     }
 }
 
@@ -560,13 +560,12 @@ export const createCommit = async (
             isPayingForClaim,
             { value: rewardAmount }
         )
-    )
-        .wait()
+    ).wait()
     return {
         commitID: getEventArgs(receipt, "CreateCommit")?.commitID,
         amount: getEventArgs(receipt, "CreateCommit")?.amount,
         commitType: getEventArgs(receipt, "CreateCommit")?.commitType,
-        receipt: receipt
+        receipt: receipt,
     }
 }
 


### PR DESCRIPTION
Closes #210 
# Motivation
When a user commits, they want the option to pay extra to get someone to claim for them when the update interval passes.

# Changes
**AutoClaim**
- Add `AutoClaim.sol`
- This has functions that allow for
    - Requesting a commit gets automatically claimed
    - Claiming a claim request and getting paid its respective reward
    - Claiming multiple claim requests, for just one `PoolCommitter` or across multiple `PoolCommitter`s
    - Withdrawing your claim request
        - This is useful in the context of giving a reward that is not high enough, you want to be able to remove this request and get your money back so it's not just sitting there permanently
- This contract should only allow claim requests to be processed if the update interval has passed from which the commit was designated.
**PoolCommitter**
- When a commit is made, user can nominate to `payForClaim`. This then passes the `msg.value` to `AutoClaim` and stores that as the reward for claiming.
- During `claim`, update the aggregate balance of `user` instead of `msg.sender`
- If the person claiming is `msg.sender` and they have a pending claim request, it should be withdrawn.
- Add `getAppropriateUpdateIntervalId` for fetching which update interval ID a commit will be placed in.
**PoolFactory**
- Add `AutoClaim` and manage it in the same way `PoolKeeper` currently is (1:n)
- Add `isValidPoolCommitter` mapping
- Add `setAutoClaim`