### PR TITLE
fix poolkeeper observer bug

### DIFF
--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -31,22 +31,11 @@ contract PoolKeeper is IPoolKeeper, Ownable {
     bytes16 constant fixedPoint = 0x403abc16d674ec800000000000000000; // 1 ether
 
     uint256 public gasPrice = 10 gwei;
-    address public observer = address(0);
 
     // #### Functions
     constructor(address _factory) {
         require(_factory != address(0), "Factory cannot be 0 address");
         factory = IPoolFactory(_factory);
-    }
-
-    /**
-     * @notice Sets the address of the associated `PriceObserver` contract
-     * @param _observer Address of the `PriceObserver` contract
-     * @dev Throws if provided address is null
-     */
-    function setPriceObserver(address _observer) external onlyOwner {
-        require(_observer != address(0), "Price observer cannot be 0 address");
-        observer = _observer;
     }
 
     /**
@@ -112,10 +101,9 @@ contract PoolKeeper is IPoolKeeper, Ownable {
 
         ILeveragedPool pool = ILeveragedPool(_pool);
 
-        /* update SMA oracle */
-        PriceObserver priceObserver = PriceObserver(observer);
-        IOracleWrapper priceObserverWriter = IOracleWrapper(priceObserver.getWriter());
-        priceObserverWriter.poll();
+        /* update SMA oracle, does nothing for spot oracles */
+        IOracleWrapper poolOracleWrapper = IOracleWrapper(pool.oracleWrapper());
+        poolOracleWrapper.poll();
 
         (int256 latestPrice, bytes memory data, uint256 savedPreviousUpdatedTimestamp, uint256 updateInterval) = pool
             .getUpkeepInformation();

--- a/test/PoolKeeper/checkUpkeepMultiplePools.spec.ts
+++ b/test/PoolKeeper/checkUpkeepMultiplePools.spec.ts
@@ -9,8 +9,6 @@ import {
     ChainlinkOracleWrapper,
     ChainlinkOracleWrapper__factory,
     TestChainlinkOracle__factory,
-    PriceObserver__factory,
-    PriceObserver,
     PoolFactory__factory,
     PoolKeeper,
     PoolKeeper__factory,
@@ -100,18 +98,6 @@ const setupHook = async () => {
 
     poolKeeper = await poolKeeperFactory.deploy(factory.address)
     await poolKeeper.deployed()
-
-    /* deploy price observer contract */
-    const priceObserverFactory = (await ethers.getContractFactory(
-        "PriceObserver",
-        signers[0]
-    )) as PriceObserver__factory
-    const priceObserver: PriceObserver = await priceObserverFactory.deploy()
-    await priceObserver.deployed()
-    await priceObserver.setWriter(oracleWrapper.address)
-
-    /* inform PoolKeeper of our newly-deployed PriceObserver contract */
-    await poolKeeper.setPriceObserver(priceObserver.address)
 
     await factory.connect(signers[0]).setPoolKeeper(poolKeeper.address)
 

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -25,8 +25,6 @@ import {
     PoolSwapLibrary,
     PoolSwapLibrary__factory,
     TestChainlinkOracle__factory,
-    PriceObserver__factory,
-    PriceObserver,
     PoolKeeper,
     PoolFactory__factory,
     PoolKeeper__factory,
@@ -182,22 +180,12 @@ export const deployPoolSetupContracts = async () => {
 
     const invariantCheck = await invariantCheckFactory.deploy(factory.address)
 
-    /* deploy price observer contract */
-    const priceObserverFactory = (await ethers.getContractFactory(
-        "PriceObserver",
-        signers[0]
-    )) as PriceObserver__factory
-    const priceObserver: PriceObserver = await priceObserverFactory.deploy()
-    await priceObserver.deployed()
-    await priceObserver.setWriter(oracleWrapper.address)
-
     const poolKeeperFactory = (await ethers.getContractFactory("PoolKeeper", {
         signer: signers[0],
         libraries: { PoolSwapLibrary: library.address },
     })) as PoolKeeper__factory
     let poolKeeper = await poolKeeperFactory.deploy(factory.address)
     poolKeeper = await poolKeeper.deployed()
-    await poolKeeper.setPriceObserver(priceObserver.address)
     await factory.setPoolKeeper(poolKeeper.address)
     await factory.setFee(DEFAULT_FEE)
 
@@ -216,7 +204,6 @@ export const deployPoolSetupContracts = async () => {
         settlementEthOracle,
         token,
         library,
-        priceObserver,
         invariantCheck,
         autoClaim,
     }
@@ -257,7 +244,6 @@ export const deployPoolAndTokenContracts = async (
     oracleWrapper: ChainlinkOracleWrapper
     settlementEthOracle: ChainlinkOracleWrapper
     invariantCheck: InvariantCheck
-    priceObserver: PriceObserver
     autoClaim: AutoClaim
 }> => {
     const setupContracts = await deployPoolSetupContracts()
@@ -496,18 +482,6 @@ export const deployMockPool = async (
     let commiter = await pool.poolCommitter()
     const poolCommitter = await ethers.getContractAt("PoolCommitter", commiter)
 
-    /* deploy price observer contract */
-    const priceObserverFactory = (await ethers.getContractFactory(
-        "PriceObserver",
-        signers[0]
-    )) as PriceObserver__factory
-    const priceObserver: PriceObserver = await priceObserverFactory.deploy()
-    await priceObserver.deployed()
-    await priceObserver.setWriter(oracleWrapper.address)
-
-    /* inform PoolKeeper of our newly-deployed PriceObserver */
-    await poolKeeper.setPriceObserver(priceObserver.address)
-
     return {
         signers,
         //@ts-ignore
@@ -526,7 +500,6 @@ export const deployMockPool = async (
         oracleWrapper,
         settlementEthOracle,
         invariantCheck,
-        priceObserver,
         autoClaim,
     }
 }


### PR DESCRIPTION
Motivation
Poolkeeper shouldn't have an observer as a variable in its storage. It should poll whichever oraclewrapper the pool it needs to update uses.

Changes
Remove poolkeeper's observer and polls whatever oracle wrapper the pool its updating uses.