### PR TITLE
AutoClaim is initializable even though it has no need to be

### DIFF
--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -5,24 +5,17 @@ import "../interfaces/IPoolFactory.sol";
 import "../interfaces/IPoolCommitter.sol";
 import "../interfaces/IAutoClaim.sol";
 
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-
 /// @title The contract to be used for paying to have a keeper claim your commit automatically
 /// @notice The way this works is when a user commits with `PoolCommitter::commit`, they have the option to set the `bool payForClaim` parameter to `true`.
 ///         During this function execution, `AutoClaim::payForClaim` is called, and `msg.value` is taken as the reward to whoever claims for requester (by using `AutoClaim::paidClaim`).
 /// @dev A question I had to ask was "What happens if one requests a second claim before one's pending request from a previous update interval one gets executed on?".
 ///      My solution to this was to have the committer instantly claim for themself. They have signified their desire to claim their tokens, after all.
-contract AutoClaim is IAutoClaim, Initializable {
+contract AutoClaim is IAutoClaim {
     // User => PoolCommitter address => Claim Request
     mapping(address => mapping(address => ClaimRequest)) public claimRequests;
     IPoolFactory internal poolFactory;
 
     constructor(address _poolFactoryAddress) {
-        require(_poolFactoryAddress != address(0), "PoolFactory address == 0");
-        poolFactory = IPoolFactory(_poolFactoryAddress);
-    }
-
-    function initialize(address _poolFactoryAddress) external override initializer {
         require(_poolFactoryAddress != address(0), "PoolFactory address == 0");
         poolFactory = IPoolFactory(_poolFactoryAddress);
     }

--- a/contracts/interfaces/IAutoClaim.sol
+++ b/contracts/interfaces/IAutoClaim.sol
@@ -44,8 +44,6 @@ interface IAutoClaim {
         uint256 reward; // The amount of ETH in wei that was given by the user to pay for upkeep
     }
 
-    function initialize(address _poolFactoryAddress) external;
-
     /**
      * @notice Pay for your commit to be claimed. This means that a willing participant can claim on `user`'s behalf when the current update interval ends.
      * @dev Only callable by this contract's associated PoolCommitter instance. This prevents griefing. Consider a permissionless function, where a user can claim that somebody else wants to auto claim when they do not.


### PR DESCRIPTION
# Motivation
While going through the CARE issues, I realised I made `Autoclaim.sol` inherit from `Initializable` even though it has no need to be.

# Changes
Removed the inheritance of `Initializable` by `AutoClaim.sol` 