### PR TITLE
Additional context in events to support capturing historic data

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -227,20 +227,22 @@ contract LeveragedPool is ILeveragedPool, Initializable, IPausable {
                 leverageAmount,
                 fee
             );
-            (uint256 newLongBalance, uint256 newShortBalance, uint256 totalFeeAmount) = PoolSwapLibrary
-                .calculatePriceChange(priceChangeData);
+            (uint256 newLongBalance, uint256 newShortBalance, uint256 longFeeAmount, uint256 shortFeeAmount) =
+                PoolSwapLibrary.calculatePriceChange(priceChangeData);
 
             unchecked {
                 emit PoolRebalance(
                     int256(newShortBalance) - int256(_shortBalance),
-                    int256(newLongBalance) - int256(_longBalance)
+                    int256(newLongBalance) - int256(_longBalance),
+                    shortFeeAmount,
+                    longFeeAmount
                 );
             }
             // Update pool balances
             longBalance = newLongBalance;
             shortBalance = newShortBalance;
             // Pay the fee
-            feeTransfer(totalFeeAmount);
+            feeTransfer(longFeeAmount + shortFeeAmount);
         }
     }
 

--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -227,8 +227,12 @@ contract LeveragedPool is ILeveragedPool, Initializable, IPausable {
                 leverageAmount,
                 fee
             );
-            (uint256 newLongBalance, uint256 newShortBalance, uint256 longFeeAmount, uint256 shortFeeAmount) =
-                PoolSwapLibrary.calculatePriceChange(priceChangeData);
+            (
+                uint256 newLongBalance,
+                uint256 newShortBalance,
+                uint256 longFeeAmount,
+                uint256 shortFeeAmount
+            ) = PoolSwapLibrary.calculatePriceChange(priceChangeData);
 
             unchecked {
                 emit PoolRebalance(

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -271,7 +271,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         }
 
         applyCommitment(pool, commitType, amount, fromAggregateBalance, userCommit, totalCommit);
-        emit CreateCommit(msg.sender, amount, commitType);
+        emit CreateCommit(msg.sender, amount, commitType, appropriateUpdateIntervalId);
     }
 
     /**

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -400,6 +400,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
     /**
      * @notice Executes all commitments currently queued for the associated `LeveragedPool`
      * @dev Only callable by the associated `LeveragedPool` contract
+     * @dev Emits an `ExecutedCommitsForInterval` event for each update interval processed
      */
     function executeCommitments() external override onlyPool checkInvariantsBeforeFunction {
         ILeveragedPool pool = ILeveragedPool(leveragedPool);

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -438,6 +438,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
                 // Another update interval has passed, so we have to do the nextIntervalCommit as well
                 burnFeeHistory[updateIntervalId] = burningFee;
                 executeGivenCommitments(totalPoolCommitments[updateIntervalId]);
+                emit ExecutedCommitsForInterval(updateIntervalId);
                 delete totalPoolCommitments[updateIntervalId];
                 updateIntervalId += 1;
             } else {

--- a/contracts/implementation/PoolSwapLibrary.sol
+++ b/contracts/implementation/PoolSwapLibrary.sol
@@ -197,12 +197,14 @@ library PoolSwapLibrary {
      * @param priceChange The struct containing necessary data to calculate price change
      * @return Resulting long balance
      * @return Resulting short balance
-     * @return Total fees (across both long and short sides) resulting from this price change
+     * @return Resulting fees taken from long balance
+     * @return Resulting fees taken from short balance
      */
     function calculatePriceChange(PriceChangeData calldata priceChange)
         external
         pure
         returns (
+            uint256,
             uint256,
             uint256,
             uint256
@@ -223,7 +225,6 @@ library PoolSwapLibrary {
 
         shortBalance = shortBalance - shortFeeAmount;
         longBalance = longBalance - longFeeAmount;
-        uint256 totalFeeAmount = shortFeeAmount + longFeeAmount;
 
         // Use the ratio to determine if the price increased or decreased and therefore which direction
         // the funds should be transferred towards.
@@ -245,7 +246,7 @@ library PoolSwapLibrary {
             longBalance = longBalance - lossAmount;
         }
 
-        return (longBalance, shortBalance, totalFeeAmount);
+        return (longBalance, shortBalance, longFeeAmount, shortFeeAmount);
     }
 
     /**

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -38,8 +38,8 @@ interface ILeveragedPool {
      * @notice Creates a notification when the pool is rebalanced
      * @param shortBalanceChange The change of funds in the short side
      * @param longBalanceChange The change of funds in the long side
-     * @param longFeeAmount Proportional fee taken from short side
-     * @param shortFeeAmount Proportional fee taken from long side
+     * @param shortFeeAmount Proportional fee taken from short side
+     * @param longFeeAmount Proportional fee taken from long side
      */
     event PoolRebalance(
         int256 shortBalanceChange,

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -38,8 +38,15 @@ interface ILeveragedPool {
      * @notice Creates a notification when the pool is rebalanced
      * @param shortBalanceChange The change of funds in the short side
      * @param longBalanceChange The change of funds in the long side
+     * @param longFeeAmount Proportional fee taken from short side
+     * @param shortFeeAmount Proportional fee taken from long side
      */
-    event PoolRebalance(int256 shortBalanceChange, int256 longBalanceChange);
+    event PoolRebalance(
+        int256 shortBalanceChange,
+        int256 longBalanceChange,
+        uint256 shortFeeAmount,
+        uint256 longFeeAmount
+    );
 
     /**
      * @notice Creates a notification when the pool's price execution fails

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -98,6 +98,11 @@ interface IPoolCommitter {
     event AggregateBalanceUpdated(address indexed user);
 
     /**
+     * @notice Creates a notification when commits for a given update interval are executed
+     */
+    event ExecutedCommitsForInterval(uint256 indexed updateIntervalId);
+
+    /**
      * @notice Creates a notification when a claim is made, depositing pool tokens in user's wallet
      */
     event Claim(address indexed user);

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -83,8 +83,14 @@ interface IPoolCommitter {
      * @param user The user making the commitment
      * @param amount Amount of the commit
      * @param commitType Type of the commit (Short v Long, Mint v Burn)
+     * @param appropriateUpdateIntervalId id of update interval where this commit can be executed as part of upkeep
      */
-    event CreateCommit(address indexed user, uint256 indexed amount, CommitType indexed commitType);
+    event CreateCommit(
+        address indexed user,
+        uint256 indexed amount,
+        CommitType indexed commitType,
+        uint256 appropriateUpdateIntervalId
+    );
 
     /**
      * @notice Creates a notification when a user's aggregate balance is updated

--- a/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
+++ b/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
@@ -225,8 +225,12 @@ contract LeveragedPoolBalanceDrainMock is ILeveragedPool, Initializable, IPausab
                 leverageAmount,
                 fee
             );
-            (uint256 newLongBalance, uint256 newShortBalance, uint256 longFeeAmount, uint256 shortFeeAmount) =
-                PoolSwapLibrary.calculatePriceChange(priceChangeData);
+            (
+                uint256 newLongBalance,
+                uint256 newShortBalance,
+                uint256 longFeeAmount,
+                uint256 shortFeeAmount
+            ) = PoolSwapLibrary.calculatePriceChange(priceChangeData);
 
             unchecked {
                 emit PoolRebalance(

--- a/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
+++ b/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
@@ -225,20 +225,22 @@ contract LeveragedPoolBalanceDrainMock is ILeveragedPool, Initializable, IPausab
                 leverageAmount,
                 fee
             );
-            (uint256 newLongBalance, uint256 newShortBalance, uint256 totalFeeAmount) = PoolSwapLibrary
-                .calculatePriceChange(priceChangeData);
+            (uint256 newLongBalance, uint256 newShortBalance, uint256 longFeeAmount, uint256 shortFeeAmount) =
+                PoolSwapLibrary.calculatePriceChange(priceChangeData);
 
             unchecked {
                 emit PoolRebalance(
                     int256(newShortBalance) - int256(_shortBalance),
-                    int256(newLongBalance) - int256(_longBalance)
+                    int256(newLongBalance) - int256(_longBalance),
+                    shortFeeAmount,
+                    longFeeAmount
                 );
             }
             // Update pool balances
             longBalance = newLongBalance;
             shortBalance = newShortBalance;
             // Pay the fee
-            feeTransfer(totalFeeAmount);
+            feeTransfer(longFeeAmount + shortFeeAmount);
         }
     }
 


### PR DESCRIPTION
# Motivation
We need to be able to calculate commit execution outcomes using historic upkeep/pricing data. We also want to be able to effectively capture historic fee data

closes https://github.com/tracer-protocol/perpetual-pools-contracts/issues/294

# Changes
- add `appropriateIntervalId` to `CreateCommit` event
- add `ExecutedCommitsForInterval` event to notify when commits for a given `updateIntervalId` are executed
- add long and short fees taken to PoolRebalance event