### PR TITLE
extra fee context in events

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -271,7 +271,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         }
 
         applyCommitment(pool, commitType, amount, fromAggregateBalance, userCommit, totalCommit);
-        emit CreateCommit(msg.sender, amount, commitType, appropriateUpdateIntervalId);
+        emit CreateCommit(msg.sender, amount, commitType, appropriateUpdateIntervalId, mintingFee);
     }
 
     /**

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -439,7 +439,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
                 // Another update interval has passed, so we have to do the nextIntervalCommit as well
                 burnFeeHistory[updateIntervalId] = burningFee;
                 executeGivenCommitments(totalPoolCommitments[updateIntervalId]);
-                emit ExecutedCommitsForInterval(updateIntervalId);
+                emit ExecutedCommitsForInterval(updateIntervalId, burningFee);
                 delete totalPoolCommitments[updateIntervalId];
                 updateIntervalId += 1;
             } else {

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -102,8 +102,9 @@ interface IPoolCommitter {
     /**
      * @notice Creates a notification when commits for a given update interval are executed
      * @param updateIntervalId Unique identifier for the relevant update interval
+     * @param burningFee Burning fee at the time of commit execution
      */
-    event ExecutedCommitsForInterval(uint256 indexed updateIntervalId);
+    event ExecutedCommitsForInterval(uint256 indexed updateIntervalId, bytes16 burningFee);
 
     /**
      * @notice Creates a notification when a claim is made, depositing pool tokens in user's wallet

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -83,13 +83,15 @@ interface IPoolCommitter {
      * @param user The user making the commitment
      * @param amount Amount of the commit
      * @param commitType Type of the commit (Short v Long, Mint v Burn)
-     * @param appropriateUpdateIntervalId id of update interval where this commit can be executed as part of upkeep
+     * @param appropriateUpdateIntervalId Id of update interval where this commit can be executed as part of upkeep
+     * @param mintingFee Minting fee at time of commit creation
      */
     event CreateCommit(
         address indexed user,
         uint256 indexed amount,
         CommitType indexed commitType,
-        uint256 appropriateUpdateIntervalId
+        uint256 appropriateUpdateIntervalId,
+        bytes16 mintingFee
     );
 
     /**


### PR DESCRIPTION
# Motivation
Need to capture fees at specific points in time in order to calculate historic user fees

# Changes
- Add `mintingFee` to `CreatedCommit` event
- Add `burningFee` to `ExecutedCommitsForInterval` event