### PR TITLE
Variable mint fee

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -25,6 +25,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
     // The amount that is extracted from each mint and burn, being left in the pool. Given as the decimal * 10 ^ 18. For example, 60% fee is 0.6 * 10 ^ 18
     bytes16 public mintingFee;
     bytes16 public burningFee;
+    // The amount that the `mintingFee` will change each update interval, based on `updateMintingFee`, given as a decimal * 10 ^ 18 (same format as `_mintingFee`)
     bytes16 public changeInterval;
     // Set max minting fee to 100%. This is a ABDKQuad representation of 1 * 10 ** 18
     bytes16 public constant MAX_MINTING_FEE = 0x403abc16d674ec800000000000000000;
@@ -122,6 +123,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         mintingFee = PoolSwapLibrary.convertUIntToDecimal(_mintingFee);
         burningFee = PoolSwapLibrary.convertUIntToDecimal(_burningFee);
         changeInterval = PoolSwapLibrary.convertUIntToDecimal(_changeInterval);
+        emit ChangeIntervalSet(_changeInterval);
         autoClaim = IAutoClaim(_autoClaim);
         governance = IPoolFactory(_factory).getOwner();
         invariantCheckContract = _invariantCheckContract;
@@ -718,6 +720,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      */
     function setBurningFee(uint256 _burningFee) external override onlyGov {
         burningFee = PoolSwapLibrary.convertUIntToDecimal(_burningFee);
+        emit BurningFeeSet(_burningFee);
     }
 
     /**
@@ -727,6 +730,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      */
     function setMintingFee(uint256 _mintingFee) external override onlyGov {
         mintingFee = PoolSwapLibrary.convertUIntToDecimal(_mintingFee);
+        emit MintingFeeSet(_mintingFee);
     }
 
     /**
@@ -736,6 +740,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      */
     function setChangeInterval(uint256 _changeInterval) external override onlyGov {
         changeInterval = PoolSwapLibrary.convertUIntToDecimal(_changeInterval);
+        emit ChangeIntervalSet(_changeInterval);
     }
 
     /**

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -104,6 +104,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @dev Only callable by the associated initialiser address
      * @dev Throws if minting fee is over 100%
      * @dev Throws if burning fee is over 100%
+     * @dev Emits a `ChangeIntervalSet` event on success
      */
     function initialize(
         address _factory,
@@ -717,6 +718,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @notice Sets the burning fee to be applied to future burn commitments indefinitely
      * @param _burningFee The new burning fee
      * @dev Converts `_burningFee` to a `bytes16` to be compatible with arithmetic library
+     * @dev Emits a `BurningFeeSet` event on success
      */
     function setBurningFee(uint256 _burningFee) external override onlyGov {
         burningFee = PoolSwapLibrary.convertUIntToDecimal(_burningFee);
@@ -727,6 +729,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @notice Sets the minting fee to be applied to future burn commitments indefinitely
      * @param _mintingFee The new minting fee
      * @dev Converts `_mintingFee` to a `bytes16` to be compatible with arithmetic library
+     * @dev Emits a `MintingFeeSet` event on success
      */
     function setMintingFee(uint256 _mintingFee) external override onlyGov {
         mintingFee = PoolSwapLibrary.convertUIntToDecimal(_mintingFee);
@@ -737,6 +740,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @notice Sets the change interval used to update the minting fee every update interval
      * @param _changeInterval The new change interval
      * @dev Converts `_changeInterval` to a `bytes16` to be compatible with arithmetic library TODO UPDATE
+     * @dev Emits a `ChangeIntervalSet` event on success
      */
     function setChangeInterval(uint256 _changeInterval) external override onlyGov {
         changeInterval = PoolSwapLibrary.convertUIntToDecimal(_changeInterval);

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -20,9 +20,14 @@ contract PoolCommitter is IPoolCommitter, Initializable {
 
     IAutoClaim public autoClaim;
     uint128 public override updateIntervalId = 1;
+    /// ABDKMathQuad-formatted representation of the number one
+    bytes16 public constant one = 0x3fff0000000000000000000000000000;
     // The amount that is extracted from each mint and burn, being left in the pool. Given as the decimal * 10 ^ 18. For example, 60% fee is 0.6 * 10 ^ 18
-    bytes16 mintingFee;
-    bytes16 burningFee;
+    bytes16 public mintingFee;
+    bytes16 public burningFee;
+    bytes16 public changeInterval;
+    // Set max minting fee to 100%. This is a ABDKQuad representation of 1 * 10 ** 18
+    bytes16 public constant MAX_MINTING_FEE = 0x403abc16d674ec800000000000000000;
 
     // Index 0 is the LONG token, index 1 is the SHORT token.
     // Fetched from the LeveragedPool when leveragedPool is set
@@ -90,6 +95,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
      * @param _autoClaim Address of the associated `AutoClaim` contract
      * @param _mintingFee The percentage that is taken from each mint, given as a decimal * 10 ^ 18
      * @param _burningFee The percentage that is taken from each burn, given as a decimal * 10 ^ 18
+     * @param _changeInterval The amount that the `mintingFee` will change each update interval, based on `updateMintingFee`, given as a decimal * 10 ^ 18 (same format as `_mintingFee`)
      * @dev Throws if factory contract address is null
      * @dev Throws if autoClaim contract address is null
      * @dev Throws if invariantCheck contract address is null
@@ -103,7 +109,8 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         address _invariantCheckContract,
         address _autoClaim,
         uint256 _mintingFee,
-        uint256 _burningFee
+        uint256 _burningFee,
+        uint256 _changeInterval
     ) external override initializer {
         require(_factory != address(0), "Factory address cannot be 0 address");
         require(_invariantCheckContract != address(0), "InvariantCheck address cannot be 0 address");
@@ -114,6 +121,7 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         factory = _factory;
         mintingFee = PoolSwapLibrary.convertUIntToDecimal(_mintingFee);
         burningFee = PoolSwapLibrary.convertUIntToDecimal(_burningFee);
+        changeInterval = PoolSwapLibrary.convertUIntToDecimal(_changeInterval);
         autoClaim = IAutoClaim(_autoClaim);
         governance = IPoolFactory(_factory).getOwner();
         invariantCheckContract = _invariantCheckContract;
@@ -445,6 +453,38 @@ contract PoolCommitter is IPoolCommitter, Initializable {
             }
             counter += 1;
         }
+
+        (uint256 shortBalance, uint256 longBalance) = pool.balances();
+
+        uint256 longTotalSupply = IERC20(tokens[LONG_INDEX]).totalSupply();
+        uint256 shortTotalSupply = IERC20(tokens[SHORT_INDEX]).totalSupply();
+
+        updateMintingFee(
+            PoolSwapLibrary.getPrice(longBalance, longTotalSupply),
+            PoolSwapLibrary.getPrice(shortBalance, shortTotalSupply)
+        );
+    }
+
+    function updateMintingFee(bytes16 longTokenPrice, bytes16 shortTokenPrice) private {
+        bytes16 multiple = PoolSwapLibrary.multiplyBytes(longTokenPrice, shortTokenPrice);
+        if (PoolSwapLibrary.compareDecimals(one, multiple) == -1) {
+            // longTokenPrice * shortTokenPrice > 1
+            if (PoolSwapLibrary.compareDecimals(mintingFee, changeInterval) == -1) {
+                // mintingFee < changeInterval. Prevent underflow by setting mintingFee to lowest possible value (0)
+                mintingFee = 0;
+            } else {
+                mintingFee = PoolSwapLibrary.subtractBytes(mintingFee, changeInterval);
+            }
+        } else {
+            // longTokenPrice * shortTokenPrice <= 1
+            mintingFee = PoolSwapLibrary.addBytes(mintingFee, changeInterval);
+
+            if (PoolSwapLibrary.compareDecimals(mintingFee, MAX_MINTING_FEE) == 1) {
+                // mintingFee is greater than 1 (100%).
+                // We want to cap this at a theoretical max of 100%
+                mintingFee = MAX_MINTING_FEE;
+            }
+        }
     }
 
     /**
@@ -669,6 +709,33 @@ contract PoolCommitter is IPoolCommitter, Initializable {
         bool approvalSuccess = _token.approve(leveragedPool, _token.totalSupply());
         require(approvalSuccess, "ERC20 approval failed");
         tokens = ILeveragedPool(leveragedPool).poolTokens();
+    }
+
+    /**
+     * @notice Sets the burning fee to be applied to future burn commitments indefinitely
+     * @param _burningFee The new burning fee
+     * @dev Converts `_burningFee` to a `bytes16` to be compatible with arithmetic library
+     */
+    function setBurningFee(uint256 _burningFee) external override onlyGov {
+        burningFee = PoolSwapLibrary.convertUIntToDecimal(_burningFee);
+    }
+
+    /**
+     * @notice Sets the minting fee to be applied to future burn commitments indefinitely
+     * @param _mintingFee The new minting fee
+     * @dev Converts `_mintingFee` to a `bytes16` to be compatible with arithmetic library
+     */
+    function setMintingFee(uint256 _mintingFee) external override onlyGov {
+        mintingFee = PoolSwapLibrary.convertUIntToDecimal(_mintingFee);
+    }
+
+    /**
+     * @notice Sets the change interval used to update the minting fee every update interval
+     * @param _changeInterval The new change interval
+     * @dev Converts `_changeInterval` to a `bytes16` to be compatible with arithmetic library TODO UPDATE
+     */
+    function setChangeInterval(uint256 _changeInterval) external override onlyGov {
+        changeInterval = PoolSwapLibrary.convertUIntToDecimal(_changeInterval);
     }
 
     /**

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -36,6 +36,8 @@ contract PoolFactory is IPoolFactory, Ownable {
     // The fee taken for each mint and burn. Fee value as a decimal multiplied by 10^18. For example, 50% is represented as 0.5 * 10^18
     uint256 public mintingFee;
     uint256 public burningFee;
+    //The interval at which the mintingFee in a market either increases or decreases, as per the logic in `PoolCommitter::updateMintingFee`
+    uint256 public changeInterval;
 
     // This is required because we must pass along *some* value for decimal
     // precision to the base pool tokens as we use the Cloneable pattern
@@ -130,7 +132,8 @@ contract PoolFactory is IPoolFactory, Ownable {
             deploymentParameters.invariantCheckContract,
             autoClaim,
             mintingFee,
-            burningFee
+            burningFee,
+            changeInterval
         );
         address poolCommitterAddress = address(poolCommitter);
 
@@ -284,15 +287,21 @@ contract PoolFactory is IPoolFactory, Ownable {
      * @dev This is a percentage in WAD; multiplied by 10^18 e.g. 5% is 0.05 * 10^18
      * @param _mintingFee The fee amount for mints
      * @param _burningFee The fee amount for burns
+     * @param _changeInterval The interval at which the mintingFee in a market either increases or decreases, as per the logic in `PoolCommitter::updateMintingFee`
      * @dev Only callable by the owner of this contract
      * @dev Throws if minting fee is greater than 10%
      * @dev Throws if burning fee is greater than 10%
      */
-    function setMintAndBurnFee(uint256 _mintingFee, uint256 _burningFee) external override onlyOwner {
+    function setMintAndBurnFeeAndChangeInterval(
+        uint256 _mintingFee,
+        uint256 _burningFee,
+        uint256 _changeInterval
+    ) external override onlyOwner {
         require(_mintingFee <= 0.1e18, "Fee cannot be > 10%");
         require(_burningFee <= 0.1e18, "Fee cannot be > 10%");
         mintingFee = _mintingFee;
         burningFee = _burningFee;
+        changeInterval = _changeInterval;
     }
 
     /*

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -297,8 +297,9 @@ contract PoolFactory is IPoolFactory, Ownable {
         uint256 _burningFee,
         uint256 _changeInterval
     ) external override onlyOwner {
-        require(_mintingFee <= 0.1e18, "Fee cannot be > 10%");
-        require(_burningFee <= 0.1e18, "Fee cannot be > 10%");
+        require(_mintingFee <= 1e18, "Fee cannot be > 100%");
+        require(_burningFee <= 1e18, "Fee cannot be > 100%");
+        require(_changeInterval <= 1e18, "Change interval cannot be > 100%");
         mintingFee = _mintingFee;
         burningFee = _burningFee;
         changeInterval = _changeInterval;

--- a/contracts/implementation/PoolSwapLibrary.sol
+++ b/contracts/implementation/PoolSwapLibrary.sol
@@ -56,6 +56,33 @@ library PoolSwapLibrary {
     }
 
     /**
+     * @notice Multiplies two numbers
+     * @param x The number to be multiplied by `y`
+     * @param y The number to be multiplied by `x`
+     */
+    function multiplyBytes(bytes16 x, bytes16 y) external pure returns (bytes16) {
+        return ABDKMathQuad.mul(x, y);
+    }
+
+    /**
+     * @notice Performs a subtraction on two bytes16 numbers
+     * @param x The number to be subtracted by `y`
+     * @param y The number to subtract from `x`
+     */
+    function subtractBytes(bytes16 x, bytes16 y) external pure returns (bytes16) {
+        return ABDKMathQuad.sub(x, y);
+    }
+
+    /**
+     * @notice Performs an addition on two bytes16 numbers
+     * @param x The number to be added with `y`
+     * @param y The number to be added with `x`
+     */
+    function addBytes(bytes16 x, bytes16 y) external pure returns (bytes16) {
+        return ABDKMathQuad.add(x, y);
+    }
+
+    /**
      * @notice Gets the short and long balances after the keeper rewards have been paid out
      *         Keeper rewards are paid proportionally to the short and long pool
      * @dev Assumes shortBalance + longBalance >= reward

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -103,7 +103,8 @@ interface IPoolCommitter {
         address _invariantCheckContract,
         address _autoClaim,
         uint256 mintingFee,
-        uint256 burningFee
+        uint256 burningFee,
+        uint256 _changeInterval
     ) external;
 
     function commit(
@@ -126,6 +127,12 @@ interface IPoolCommitter {
     function getAppropriateUpdateIntervalId() external view returns (uint128);
 
     function setQuoteAndPool(address _quoteToken, address _leveragedPool) external;
+
+    function setBurningFee(uint256 _burningFee) external;
+
+    function setMintingFee(uint256 _mintingFee) external;
+
+    function setChangeInterval(uint256 _changeInterval) external;
 
     function getPendingCommits() external view returns (TotalCommitment memory, TotalCommitment memory);
 }

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -96,6 +96,21 @@ interface IPoolCommitter {
      */
     event Claim(address indexed user);
 
+    /**
+     * @notice Creates a notification when the burningFee is updated
+     */
+    event BurningFeeSet(uint256 indexed _burningFee);
+
+    /**
+     * @notice Creates a notification when the mintingFee is updated
+     */
+    event MintingFeeSet(uint256 indexed _mintingFee);
+
+    /**
+     * @notice Creates a notification when the changeInterval is updated
+     */
+    event ChangeIntervalSet(uint256 indexed _changeInterval);
+
     // #### Functions
 
     function initialize(

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -54,5 +54,9 @@ interface IPoolFactory {
 
     function setSecondaryFeeSplitPercent(uint256 newFeePercent) external;
 
-    function setMintAndBurnFee(uint256 _mintingFee, uint256 _burningFee) external;
+    function setMintAndBurnFeeAndChangeInterval(
+        uint256 _mintingFee,
+        uint256 _burningFee,
+        uint256 _changeInterval
+    ) external;
 }

--- a/test/PoolKeeper/performUpkeep/fees.spec.ts
+++ b/test/PoolKeeper/performUpkeep/fees.spec.ts
@@ -73,17 +73,51 @@ describe("Leveraged pool fees", () => {
     it("Should revert if fee above 10%", async () => {
         const setupContracts = await deployPoolSetupContracts()
 
-        // deploy the pool using the factory, not separately
-        const deployParams = {
-            poolName: POOL_CODE,
-            frontRunningInterval: frontRunningInterval,
-            updateInterval: updateInterval,
-            leverageAmount: 1,
-            quoteToken: setupContracts.token.address,
-            oracleWrapper: setupContracts.oracleWrapper.address,
-            settlementEthOracle: setupContracts.settlementEthOracle.address,
-            invariantCheckContract: setupContracts.invariantCheck.address,
-        }
+        await expect(
+            setupContracts.factory.setFee(ethers.utils.parseEther("100"))
+        ).to.be.revertedWith("Fee cannot be > 10%")
+    })
+
+    context("setMintAndBurnFeeAndChangeInterval", async () => {
+        let setupContracts: any
+
+        before(async () => {
+            setupContracts = await deployPoolSetupContracts()
+        })
+
+        it("Should revert if mintingFee > 100%", async () => {
+            await expect(
+                setupContracts.factory.setMintAndBurnFeeAndChangeInterval(
+                    ethers.utils.parseEther("100"),
+                    0,
+                    0
+                )
+            ).to.be.revertedWith("Fee cannot be > 100%")
+        })
+
+        it("Should revert if burningFee > 100%", async () => {
+            await expect(
+                setupContracts.factory.setMintAndBurnFeeAndChangeInterval(
+                    0,
+                    ethers.utils.parseEther("100"),
+                    0
+                )
+            ).to.be.revertedWith("Fee cannot be > 100%")
+        })
+
+        it("Should revert if changeInterval > 100%", async () => {
+            await expect(
+                setupContracts.factory.setMintAndBurnFeeAndChangeInterval(
+                    0,
+                    0,
+                    ethers.utils.parseEther("100")
+                )
+            ).to.be.revertedWith("Change interval cannot be > 100%")
+        })
+    })
+
+    it("Should revert if fee above 10%", async () => {
+        const setupContracts = await deployPoolSetupContracts()
 
         await expect(
             setupContracts.factory.setFee(ethers.utils.parseEther("100"))

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -242,7 +242,8 @@ export const deployPoolAndTokenContracts = async (
     feeAddress?: string,
     fee?: BigNumberish,
     mintFee?: BigNumberish,
-    burnFee?: BigNumberish
+    burnFee?: BigNumberish,
+    changeInterval?: BigNumberish
 ): Promise<{
     signers: SignerWithAddress[]
     pool: LeveragedPool
@@ -280,10 +281,11 @@ export const deployPoolAndTokenContracts = async (
     if (feeAddress) {
         await setupContracts.factory.setFeeReceiver(feeAddress)
     }
-    if (mintFee || burnFee) {
-        await setupContracts.factory.setMintAndBurnFee(
+    if (mintFee || burnFee || changeInterval) {
+        await setupContracts.factory.setMintAndBurnFeeAndChangeInterval(
             mintFee || 0,
-            burnFee || 0
+            burnFee || 0,
+            changeInterval || 0
         )
     }
     await setupContracts.factory.deployPool(deployParams)


### PR DESCRIPTION
Closes #298 

Please see issue #298  and the relevant discussion #282 for all details.

# Motivation

We want a variable mint fee which **goes up when `longTokenPrice * shortTokenPrice <= 1` and goes down if `longTokenPrice * shortTokenPrice > 1`** (to summarise).

**note:** burning fee doesn't have this mechanism and just remains constant.

We also want `burningFee`, `mintingFee`, and `changeInterval` to be modifiable by governance.

# Changes
- Add `setBurningFee`, `setMintingFee`, and `setChangeInterval` setters.
- `_changeInterval` is now a param for `PoolCommitter`
- `changeInterval` is set along with `mintingFee` and `burningFee` in `PoolFactory`
- Add `function updateMintingFee(bytes16 longTokenPrice, bytes16 shortTokenPrice) private;`
    - This updates the minting fee after each update interval.