### PR TITLE
fix(SMA): change PriceObserver to always leftShift array

### DIFF
--- a/contracts/implementation/PriceObserver.sol
+++ b/contracts/implementation/PriceObserver.sol
@@ -45,7 +45,7 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @dev Throws if index is out of bounds (i.e., `i >= length()`)
      */
     function get(uint256 i) public view override returns (int256) {
-        require(i < length(), "PO: Out of bounds");
+        require(i < capacity(), "PO: Out of bounds");
         return observations[i];
     }
 
@@ -68,11 +68,10 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @dev Only callable by the associated writer for this contract
      */
     function add(int256 x) public override onlyWriter returns (bool) {
+        leftRotateWithPad(x);
         if (full()) {
-            leftRotateWithPad(x);
             return true;
         } else {
-            observations[length()] = x;
             numElems += 1;
             return false;
         }
@@ -122,7 +121,7 @@ contract PriceObserver is Ownable, IPriceObserver {
      * @param x Element to "rotate into" observations array
      */
     function leftRotateWithPad(int256 x) private {
-        uint256 n = length();
+        uint256 n = observations.length;
 
         /* linear scan over the [1, n] subsequence */
         for (uint256 i = 1; i < n; i++) {

--- a/test/PriceObserver.spec.ts
+++ b/test/PriceObserver.spec.ts
@@ -97,10 +97,10 @@ describe("PriceObserver", async () => {
 
     describe("get", async () => {
         context(
-            "When called with an index greater than the length of the observations array",
+            "When called with an index greater than the capacity of the observations array",
             async () => {
                 it("Reverts", async () => {
-                    let index: BigNumber = (await priceObserver.length()).add(
+                    let index: BigNumber = (await priceObserver.capacity()).add(
                         ethers.BigNumber.from(1)
                     )
 
@@ -112,10 +112,10 @@ describe("PriceObserver", async () => {
         )
 
         context(
-            "When called with an index equal to the length of the observations array",
+            "When called with an index equal to the capacity of the observations array",
             async () => {
                 it("Reverts", async () => {
-                    let index: BigNumber = await priceObserver.length()
+                    let index: BigNumber = await priceObserver.capacity()
 
                     await expect(priceObserver.get(index)).to.be.revertedWith(
                         "PO: Out of bounds"
@@ -129,14 +129,13 @@ describe("PriceObserver", async () => {
         context(
             "When called with an observations array less than capacity",
             async () => {
-                it("Updates the observations array at the next free slot", async () => {
+                it("Adds the value to the end of the array", async () => {
                     const newValue: BigNumberish = 12
-                    const previousLength: BigNumber =
-                        await priceObserver.length()
+                    const capacity: BigNumber = await priceObserver.capacity()
 
                     await priceObserver.add(newValue)
 
-                    expect(await priceObserver.get(previousLength)).to.be.eq(
+                    expect(await priceObserver.get(capacity.sub(1))).to.be.eq(
                         newValue
                     )
                 })

--- a/test/SMAOracle.spec.ts
+++ b/test/SMAOracle.spec.ts
@@ -36,7 +36,7 @@ describe("SMAOracle", async () => {
     let numPeriods: BigNumberish
     let updateInterval: BigNumberish
 
-    before(async () => {
+    beforeEach(async () => {
         /* retrieve signers */
         signers = await ethers.getSigners()
         owner = signers[0]
@@ -127,7 +127,7 @@ describe("SMAOracle", async () => {
 
     describe("SMA", async () => {
         context(
-            "When called with number of periods less than the size of the dataset and with a valid dataset",
+            "When called with number of periods less than the size of the dataset and with a full dataset",
             async () => {
                 it("Returns the correct simple moving average", async () => {
                     /* xs is arbitrary (provided it's 24 elements long) */
@@ -148,7 +148,7 @@ describe("SMAOracle", async () => {
         )
 
         context(
-            "When called with number of periods equal to the size of the dataset and with a valid dataset",
+            "When called with number of periods equal to the size of the dataset and with a full dataset",
             async () => {
                 it("Returns the correct simple moving average", async () => {
                     /* xs is arbitrary (provided it's 24 elements long) */
@@ -215,14 +215,21 @@ describe("SMAOracle", async () => {
     describe("poll", async () => {
         context("When called while ramping up", async () => {
             context("When called the first time", async () => {
-                let spotPrice: BigNumberish = 12 /* arbitrary */
+                const unitPrice = 12
+                const spotPrice = ethers.utils.parseUnits(
+                    unitPrice.toString(),
+                    8
+                )
 
                 beforeEach(async () => {
                     await chainlinkOracle.setPrice(spotPrice)
                 })
 
-                it.skip("Returns spot price", async () => {
-                    const expectedPrice: BigNumberish = spotPrice
+                it("Returns spot price", async () => {
+                    const expectedPrice = ethers.utils.parseUnits(
+                        unitPrice.toString(),
+                        18
+                    )
 
                     await smaOracle.poll()
 
@@ -233,9 +240,10 @@ describe("SMAOracle", async () => {
             })
 
             context("When called the second time", async () => {
-                let spotPrices: BigNumber[] = [12, 33].map((x) =>
-                    ethers.BigNumber.from(x)
-                ) /* arbitrary */
+                const unitPrices = [12, 33] /* arbitrary */
+                let spotPrices = unitPrices.map((unitPrice) =>
+                    ethers.utils.parseUnits(unitPrice.toString(), 8)
+                )
 
                 beforeEach(async () => {
                     await chainlinkOracle.setPrice(spotPrices[0])
@@ -243,10 +251,13 @@ describe("SMAOracle", async () => {
                     await chainlinkOracle.setPrice(spotPrices[1])
                 })
 
-                it.skip("Returns price averaged over two periods", async () => {
-                    const expectedPrice: BigNumber = spotPrices[0]
-                        .add(spotPrices[1])
-                        .div(ethers.BigNumber.from(2))
+                it("Returns price averaged over two periods", async () => {
+                    const expectedUnitPrice =
+                        (unitPrices[0] + unitPrices[1]) / 2
+                    const expectedPrice = ethers.utils.parseUnits(
+                        expectedUnitPrice.toString(),
+                        18
+                    )
 
                     await smaOracle.poll()
 


### PR DESCRIPTION
## Changelog
- Change `IPriceObserver.add` to always left shift array so the final `k` positions of that array are always correct for SMA calculation
- Update restrictions to allow getting of items as long as they are less than `capacity`
- Update tests

## Notes
Since we are always going to be shifting the array, it might be more intuitive to change it to right-shifting so the first `k` items are used in the calculations and the `require(x < length())` statements can still apply