### PR TITLE
Wrong initial execution price

### DIFF
--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -47,9 +47,8 @@ contract PoolKeeper is IPoolKeeper, Ownable {
         address oracleWrapper = ILeveragedPool(_poolAddress).oracleWrapper();
         int256 firstPrice = IOracleWrapper(oracleWrapper).getPrice();
         require(firstPrice > 0, "First price is non-positive");
-        int256 startingPrice = firstPrice;
         emit PoolAdded(_poolAddress, firstPrice);
-        executionPrice[_poolAddress] = startingPrice;
+        executionPrice[_poolAddress] = firstPrice;
     }
 
     /**


### PR DESCRIPTION
# Issue
#323 

# Changes
 - Make `executionPrice` the same as `firstPrice` upon pool creation (in `PoolKeeper::newPool`)