### PR TITLE
Use token index in mint and burn param

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -333,43 +333,35 @@ contract LeveragedPool is ILeveragedPool, Initializable, IPausable, ITwoStepGove
 
     /**
      * @notice Mint tokens to a user
-     * @param isLongToken True if minting long token; False if minting short token
+     * @param tokenType LONG_INDEX (0) or SHORT_INDEX (1) for either minting the long or short  token respectively
      * @param amount Amount of tokens to mint
      * @param minter Address of user/minter
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
      */
     function mintTokens(
-        bool isLongToken,
+        uint256 tokenType,
         uint256 amount,
         address minter
     ) external override onlyPoolCommitter checkInvariantsBeforeFunction {
-        if (isLongToken) {
-            IPoolToken(tokens[LONG_INDEX]).mint(minter, amount);
-        } else {
-            IPoolToken(tokens[SHORT_INDEX]).mint(minter, amount);
-        }
+        IPoolToken(tokens[tokenType]).mint(minter, amount);
     }
 
     /**
      * @notice Burn tokens by a user
      * @dev Can only be called by & used by the pool committer
-     * @param isLongToken True if burning long token; False if burning short token
+     * @param tokenType LONG_INDEX (0) or SHORT_INDEX (1) for either burning the long or short  token respectively
      * @param amount Amount of tokens to burn
      * @param burner Address of user/burner
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
      */
     function burnTokens(
-        bool isLongToken,
+        uint256 tokenType,
         uint256 amount,
         address burner
     ) external override onlyPoolCommitter checkInvariantsAfterFunction {
-        if (isLongToken) {
-            IPoolToken(tokens[LONG_INDEX]).burn(burner, amount);
-        } else {
-            IPoolToken(tokens[SHORT_INDEX]).burn(burner, amount);
-        }
+        IPoolToken(tokens[tokenType]).burn(burner, amount);
     }
 
     /**

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -202,10 +202,10 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
                 // This require statement is only needed in this branch, as `pool.burnTokens` will revert if burning too many
                 require(userCommit.balanceLongBurnAmount <= balance.longTokens, "Insufficient pool tokens");
                 // Burn from leveragedPool, because that is the official owner of the tokens before they are claimed
-                pool.burnTokens(true, amount, leveragedPool);
+                pool.burnTokens(LONG_INDEX, amount, leveragedPool);
             } else {
                 // Burning from user's wallet
-                pool.burnTokens(true, amount, msg.sender);
+                pool.burnTokens(LONG_INDEX, amount, msg.sender);
             }
         } else if (commitType == CommitType.ShortMint) {
             (uint256 shortBalance, uint256 longBalance) = pool.balances();
@@ -223,10 +223,10 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
                 // This require statement is only needed in this branch, as `pool.burnTokens` will revert if burning too many
                 require(userCommit.balanceShortBurnAmount <= balance.shortTokens, "Insufficient pool tokens");
                 // Burn from leveragedPool, because that is the official owner of the tokens before they are claimed
-                pool.burnTokens(false, amount, leveragedPool);
+                pool.burnTokens(SHORT_INDEX, amount, leveragedPool);
             } else {
                 // Burning from user's wallet
-                pool.burnTokens(false, amount, msg.sender);
+                pool.burnTokens(SHORT_INDEX, amount, msg.sender);
             }
         } else if (commitType == CommitType.LongBurnShortMint) {
             userCommit.longBurnShortMintAmount += amount;
@@ -234,9 +234,9 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
             if (fromAggregateBalance) {
                 userCommit.balanceLongBurnMintAmount += amount;
                 require(userCommit.balanceLongBurnMintAmount <= balance.longTokens, "Insufficient pool tokens");
-                pool.burnTokens(true, amount, leveragedPool);
+                pool.burnTokens(LONG_INDEX, amount, leveragedPool);
             } else {
-                pool.burnTokens(true, amount, msg.sender);
+                pool.burnTokens(LONG_INDEX, amount, msg.sender);
             }
         } else if (commitType == CommitType.ShortBurnLongMint) {
             userCommit.shortBurnLongMintAmount += amount;
@@ -244,9 +244,9 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
             if (fromAggregateBalance) {
                 userCommit.balanceShortBurnMintAmount += amount;
                 require(userCommit.balanceShortBurnMintAmount <= balance.shortTokens, "Insufficient pool tokens");
-                pool.burnTokens(false, amount, leveragedPool);
+                pool.burnTokens(SHORT_INDEX, amount, leveragedPool);
             } else {
-                pool.burnTokens(false, amount, msg.sender);
+                pool.burnTokens(SHORT_INDEX, amount, msg.sender);
             }
         }
     }
@@ -429,7 +429,7 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         );
 
         if (longMintAmount > 0) {
-            pool.mintTokens(true, longMintAmount, leveragedPool);
+            pool.mintTokens(LONG_INDEX, longMintAmount, leveragedPool);
         }
 
         // Long Burns
@@ -449,7 +449,7 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         );
 
         if (shortMintAmount > 0) {
-            pool.mintTokens(false, shortMintAmount, leveragedPool);
+            pool.mintTokens(SHORT_INDEX, shortMintAmount, leveragedPool);
         }
 
         // Short Burns

--- a/contracts/interfaces/ILeveragedPool.sol
+++ b/contracts/interfaces/ILeveragedPool.sol
@@ -181,13 +181,13 @@ interface ILeveragedPool {
     function updateSecondaryFeeAddress(address account) external;
 
     function mintTokens(
-        bool isLongToken,
+        uint256 tokenType,
         uint256 amount,
         address burner
     ) external;
 
     function burnTokens(
-        bool isLongToken,
+        uint256 tokenType,
         uint256 amount,
         address burner
     ) external;

--- a/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
+++ b/contracts/test-utilities/LeveragedPoolBalanceDrainMock.sol
@@ -332,43 +332,34 @@ contract LeveragedPoolBalanceDrainMock is ILeveragedPool, Initializable, IPausab
 
     /**
      * @notice Mint tokens to a user
-     * @param isLongToken True if minting long token; False if burning short token
      * @param amount Amount of tokens to mint
      * @param minter Address of user/minter
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
      */
     function mintTokens(
-        bool isLongToken,
+        uint256 tokenType,
         uint256 amount,
         address minter
     ) external override onlyPoolCommitter checkInvariantsBeforeFunction {
-        if (isLongToken) {
-            IPoolToken(tokens[LONG_INDEX]).mint(minter, amount);
-        } else {
-            IPoolToken(tokens[SHORT_INDEX]).mint(minter, amount);
-        }
+        IPoolToken(tokens[tokenType]).mint(minter, amount);
     }
 
     /**
      * @notice Burn tokens by a user
      * @dev Can only be called by & used by the pool committer
-     * @param isLongToken True if burning long token; False if burning short token
+     * @param tokenType LONG_INDEX (0) or SHORT_INDEX (1) for either minting the long or short  token respectively
      * @param amount Amount of tokens to burn
      * @param burner Address of user/burner
      * @dev Only callable by the associated `PoolCommitter` contract
      * @dev Only callable when the market is *not* paused
      */
     function burnTokens(
-        bool isLongToken,
+        uint256 tokenType,
         uint256 amount,
         address burner
     ) external override onlyPoolCommitter checkInvariantsAfterFunction {
-        if (isLongToken) {
-            IPoolToken(tokens[LONG_INDEX]).burn(burner, amount);
-        } else {
-            IPoolToken(tokens[SHORT_INDEX]).burn(burner, amount);
-        }
+        IPoolToken(tokens[tokenType]).burn(burner, amount);
     }
 
     /**


### PR DESCRIPTION
Closes #337 

# Motivation
We can avoid an `if else` block if we just give the token index to `LeveragedPool::mintTokens` and `LeveragedPool::burnTokens`

I originally passed in a `bool` a while back because I was a noob and didn't realise everything was padded to 32 bytes anyway and was trying to save `calldata` space.