### PR TITLE
Use total pending burn amount in calculations

### DIFF
--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -162,6 +162,10 @@ interface IPoolCommitter {
 
     function totalPendingMints() external view returns (uint256);
 
+    function totalPendingShortBurns() external view returns (uint256);
+
+    function totalPendingLongBurns() external view returns (uint256);
+
     function claim(address user) external;
 
     function executeCommitments() external;


### PR DESCRIPTION
Closes #342 

# Notes
I attempted to solve the issue linked by creating two `uint256` variables: `totalPendingLongBurns` and `totalPendingShortBurns`. These can then be used to add back to the total supply for the pool tokens, to "undo" the burning of tokens for update intervals which have not yet been executed.

As a reminder/summary, the bug has been caused by not adding back _all_ burnt tokens from future update intervals.

I believe this to be correct because of:
a) Manually reasoning about logic.
b) Two regression tests for the example given in the spearbit audit, which (correctly) failed previously are now passing.