### PR TITLE
`quoteToken` -> `settlementToken` in `DeployCommitter` event

### DIFF
--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -35,14 +35,14 @@ interface IPoolFactory {
     /**
      * @notice Creates a notification when a PoolCommitter is deployed
      * @param poolCommitterAddress Address of new PoolCommitter
-     * @param quoteToken Address of new quoteToken
+     * @param settlementToken Address of new settlementToken
      * @param pool Address of the pool associated with this PoolCommitter
      * @param changeInterval The amount that the `mintingFee` will change each update interval, based on `updateMintingFee`, given as a decimal * 10 ^ 18 (same format as `_mintingFee`)
      * @param feeController The address that has control over fee parameters
      */
     event DeployCommitter(
         address poolCommitterAddress,
-        address quoteToken,
+        address settlementToken,
         address pool,
         uint256 changeInterval,
         address feeController


### PR DESCRIPTION
was updating api and subgraph to be consistent with this terminology and noticed we were still using `quoteToken` in this spot.