### PR TITLE
Remove UserCommit.balance* fields

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -194,7 +194,6 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
                 // Burning from user's aggregate balance
                 require(amount <= balance.longTokens, "Insufficient pool tokens");
                 userAggregateBalance[msg.sender].longTokens -= amount;
-                userCommit.balanceLongBurnPoolTokens += amount;
                 // Burn from leveragedPool, because that is the official owner of the tokens before they are claimed
                 pool.burnTokens(LONG_INDEX, amount, leveragedPool);
             } else {
@@ -216,7 +215,6 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
                 // Burning from user's aggregate balance
                 require(amount <= balance.shortTokens, "Insufficient pool tokens");
                 userAggregateBalance[msg.sender].shortTokens -= amount;
-                userCommit.balanceShortBurnPoolTokens += amount;
                 // Burn from leveragedPool, because that is the official owner of the tokens before they are claimed
                 pool.burnTokens(SHORT_INDEX, amount, leveragedPool);
             } else {
@@ -230,7 +228,6 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
             if (fromAggregateBalance) {
                 require(amount <= balance.longTokens, "Insufficient pool tokens");
                 userAggregateBalance[msg.sender].longTokens -= amount;
-                userCommit.balanceLongBurnMintPoolTokens += amount;
                 pool.burnTokens(LONG_INDEX, amount, leveragedPool);
             } else {
                 pool.burnTokens(LONG_INDEX, amount, msg.sender);
@@ -242,7 +239,6 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
             if (fromAggregateBalance) {
                 require(amount <= balance.shortTokens, "Insufficient pool tokens");
                 userAggregateBalance[msg.sender].shortTokens -= amount;
-                userCommit.balanceShortBurnMintPoolTokens += amount;
                 pool.burnTokens(SHORT_INDEX, amount, leveragedPool);
             } else {
                 pool.burnTokens(SHORT_INDEX, amount, msg.sender);
@@ -737,11 +733,6 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
                 }
                 commitmentIds.pop();
             } else {
-                // Clear them now that they have been accounted for in the balance
-                userCommitments[user][id].balanceLongBurnPoolTokens = 0;
-                userCommitments[user][id].balanceShortBurnPoolTokens = 0;
-                userCommitments[user][id].balanceLongBurnMintPoolTokens = 0;
-                userCommitments[user][id].balanceShortBurnMintPoolTokens = 0;
                 // This commitment wasn't ready to be completely added to the balance, so copy it over into the new ID array
                 if (unAggregatedLength <= MAX_ITERATIONS) {
                     storageArrayPlaceHolder.push(currentIntervalIds[i]);

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -72,14 +72,10 @@ interface IPoolCommitter {
     struct UserCommitment {
         uint256 longMintSettlement;
         uint256 longBurnPoolTokens;
-        uint256 balanceLongBurnPoolTokens;
         uint256 shortMintSettlement;
         uint256 shortBurnPoolTokens;
-        uint256 balanceShortBurnPoolTokens;
         uint256 shortBurnLongMintPoolTokens;
-        uint256 balanceShortBurnMintPoolTokens;
         uint256 longBurnShortMintPoolTokens;
-        uint256 balanceLongBurnMintPoolTokens;
         uint256 updateIntervalId;
     }
 

--- a/test/PoolCommitter/commit.spec.ts
+++ b/test/PoolCommitter/commit.spec.ts
@@ -258,9 +258,6 @@ describe("PoolCommitter - commit", () => {
                 shortTokenSupplyBefore.sub(amountCommitted)
             ) // Supply decreases
             // Commitment storage updates
-            expect(userMostRecentCommit.balanceShortBurnPoolTokens).to.equal(
-                amountCommitted
-            )
             expect(userMostRecentCommit.shortBurnPoolTokens).to.equal(
                 amountCommitted
             )
@@ -330,10 +327,6 @@ describe("PoolCommitter - commit", () => {
                 poolCommitter
             )
 
-            // balanceShortBurnPoolTokens is updated
-            expect(userCommit.balanceShortBurnPoolTokens).to.equal(
-                amountCommitted
-            )
             /* SHORT_BURN COMMIT */
             await createCommit(
                 l2Encoder,
@@ -357,8 +350,6 @@ describe("PoolCommitter - commit", () => {
                 shortTokenSupplyBefore.sub(amountCommitted).sub(amountCommitted)
             )
 
-            // balanceShortBurnPoolTokens gets cleared, because on the update from the second `commit`, it is used and can then be cleared
-            expect(userMostRecentCommit.balanceShortBurnPoolTokens).to.equal(0)
             expect(userMostRecentCommit.shortBurnPoolTokens).to.equal(
                 amountCommitted.mul(2)
             )
@@ -596,9 +587,6 @@ describe("PoolCommitter - commit", () => {
                 longTokenSupplyBefore.sub(amountCommitted)
             ) // Supply decreases
             // Commitment storage updates
-            expect(userMostRecentCommit.balanceLongBurnPoolTokens).to.equal(
-                amountCommitted
-            )
             expect(userMostRecentCommit.longBurnPoolTokens).to.equal(
                 amountCommitted
             )
@@ -665,10 +653,6 @@ describe("PoolCommitter - commit", () => {
                 poolCommitter
             )
 
-            // balanceLongBurnPoolTokens is updated
-            expect(userCommit.balanceLongBurnPoolTokens).to.equal(
-                amountCommitted
-            )
             await createCommit(
                 l2Encoder,
                 poolCommitter,
@@ -691,8 +675,6 @@ describe("PoolCommitter - commit", () => {
                 poolCommitter
             )
 
-            // balanceLongBurnPoolTokens gets cleared, because on the update from the second `commit`, it is used and can then be cleared
-            expect(userMostRecentCommit.balanceLongBurnPoolTokens).to.equal(0)
             expect(userMostRecentCommit.longBurnPoolTokens).to.equal(
                 amountCommitted.mul(2)
             )
@@ -1132,9 +1114,6 @@ describe("PoolCommitter - commit", () => {
                 )
                 // Commitment storage updates
                 expect(
-                    userMostRecentCommit.balanceLongBurnMintPoolTokens
-                ).to.equal(amountCommitted)
-                expect(
                     userMostRecentCommit.longBurnShortMintPoolTokens
                 ).to.equal(amountCommitted)
                 expect(totalMostRecentCommit.longBurnPoolTokens).to.equal(0)
@@ -1329,15 +1308,6 @@ describe("PoolCommitter - commit", () => {
                     let shortBalance = await pool.shortBalance()
                     expect(longBalance).to.equal(amountCommitted)
                     expect(shortBalance).to.equal(0)
-
-                    expect(
-                        (
-                            await getCurrentUserCommit(
-                                signers[0].address,
-                                poolCommitter
-                            )
-                        ).balanceLongBurnMintPoolTokens
-                    ).to.equal(amountCommitted)
                     expect(
                         (
                             await getCurrentUserCommit(
@@ -1437,9 +1407,6 @@ describe("PoolCommitter - commit", () => {
                 longTokenSupplyBefore.sub(amountCommitted)
             )
             // Commitment storage updates
-            expect(userMostRecentCommit.balanceLongBurnMintPoolTokens).to.equal(
-                0
-            )
             expect(userMostRecentCommit.longBurnShortMintPoolTokens).to.equal(
                 amountCommitted
             )
@@ -1718,9 +1685,6 @@ describe("PoolCommitter - commit", () => {
                 shortTokenSupplyBefore.sub(amountCommitted)
             )
             // Commitment storage updates
-            expect(
-                userMostRecentCommit.balanceShortBurnMintPoolTokens
-            ).to.equal(0)
             expect(userMostRecentCommit.shortBurnLongMintPoolTokens).to.equal(
                 amountCommitted
             )


### PR DESCRIPTION
All the fields matching `UserCommit.balance*` in the `UserCommit` struct found in `IPoolCommitter` are no longer needed and are used needlessly.

This is because we now update the user's aggregate balance at commit time for commits coming from aggregate balance.