### PR TITLE
Remove old transfer of fees

### DIFF
--- a/contracts/implementation/LeveragedPool.sol
+++ b/contracts/implementation/LeveragedPool.sol
@@ -345,18 +345,9 @@ contract LeveragedPool is ILeveragedPool, Initializable, IPausable, ITwoStepGove
                 // secondaryFee is calculated as totalFeeAmount * secondaryFeeSplitPercent / 100
                 // secondaryFeeSplitPercent <= 100 and therefore secondaryFee <= totalFeeAmount - The following line can not underflow
                 remainder = totalFeeAmount - secondaryFee;
-            }
-            IERC20 _settlementToken = IERC20(settlementToken);
-            unchecked {
                 // Overflow would require more than settlement's entire total supply
                 secondaryFees += secondaryFee;
                 primaryFees += remainder;
-            }
-            if (secondaryFee != 0) {
-                _settlementToken.safeTransfer(secondaryFeeAddress, secondaryFee);
-            }
-            if (remainder != 0) {
-                _settlementToken.safeTransfer(feeAddress, remainder);
             }
         }
     }

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -400,6 +400,8 @@ describe("PoolFactory.deployPool", () => {
                 BigNumber.from("2").mul(lastPrice)
             )
 
+            await newPool.claimPrimaryFees()
+            await newPool.claimSecondaryFees()
             let feesPaidPrimary = await token.balanceOf(feeAddress)
             let feesPaidSecondary = await token.balanceOf(secondFeeAddress)
             expect(


### PR DESCRIPTION
Discovered by @0xleastwood , protocol fees can be transferred twice.

# Changes
- Make it so the only way of receiving fees is through the `claim*Fees` functions.