### PR TITLE
Make autoclaim events more useful

### DIFF
--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -57,7 +57,7 @@ contract AutoClaim is IAutoClaim {
                 // If the claim request is pending but not yet valid (it was made in the current commit), we want to add to the value.
                 // Note that in context, the user *usually* won't need or want to increment `ClaimRequest.reward` more than once because the first call to `payForClaim` should suffice.
                 request.reward += msg.value;
-                emit PaidClaimRequestUpdate(user, msg.sender, request.reward);
+                emit PaidClaimRequestUpdate(user, msg.sender, request.updateIntervalId, request.reward);
                 return;
             }
         }
@@ -66,7 +66,7 @@ contract AutoClaim is IAutoClaim {
         requestUpdateIntervalId = poolCommitter.getAppropriateUpdateIntervalId();
         request.updateIntervalId = requestUpdateIntervalId;
         request.reward = msg.value;
-        emit PaidClaimRequestUpdate(user, msg.sender, request.reward);
+        emit PaidClaimRequestUpdate(user, msg.sender, requestUpdateIntervalId, request.reward);
     }
 
     /**

--- a/contracts/interfaces/IAutoClaim.sol
+++ b/contracts/interfaces/IAutoClaim.sol
@@ -3,26 +3,18 @@ pragma solidity 0.8.7;
 
 interface IAutoClaim {
     /**
-     * @notice Creates a notification when an auto-claim is requested
-     * @param user The user who made a request
-     * @param poolCommitter The PoolCommitter instance in which the commit was made
-     * @param updateIntervalId The update interval ID that the corresponding commitment was allocated for
-     * @param reward The reward for the auto-claim
-     */
-    event PaidClaimRequest(
-        address indexed user,
-        address indexed poolCommitter,
-        uint256 indexed updateIntervalId,
-        uint256 reward
-    );
-
-    /**
      * @notice Creates a notification when an auto-claim request is updated. i.e. When another commit is added and reward is incremented.
      * @param user The user whose request got updated
      * @param poolCommitter The PoolCommitter instance in which the commits were made
+     * @param updateIntervalId The update interval ID that the corresponding commitment was allocated for
      * @param newReward The new total reward for the auto-claim
      */
-    event PaidClaimRequestUpdate(address indexed user, address indexed poolCommitter, uint256 indexed newReward);
+    event PaidClaimRequestUpdate(
+        address indexed user,
+        address indexed poolCommitter,
+        uint256 indexed updateIntervalId,
+        uint256 newReward
+    );
 
     /**
      * @notice Creates a notification when an auto-claim request is executed


### PR DESCRIPTION
Closes #445 

# Changes
- Delete `event PaidClaimRequest`
- Make `event PaidClaimRequestUpdate` emit the appropriate update interval ID.