### PR TITLE
Correctly filter commit type on mint

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -309,7 +309,7 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
 
         applyCommitment(pool, commitType, amount, fromAggregateBalance, userCommit, totalCommit);
 
-        if (commitType == CommitType.LongMint || (commitType == CommitType.ShortMint && !fromAggregateBalance)) {
+        if ((commitType == CommitType.LongMint || commitType == CommitType.ShortMint) && !fromAggregateBalance) {
             // minting: pull in the settlement token from the committer
             // Do not need to transfer if minting using aggregate balance tokens, since the leveraged pool already owns these tokens.
             pool.settlementTokenTransferFrom(msg.sender, leveragedPool, amount);

--- a/test/PoolCommitter/commit.spec.ts
+++ b/test/PoolCommitter/commit.spec.ts
@@ -416,6 +416,7 @@ describe("PoolCommitter - commit", () => {
         it("Should appropriately set values", async () => {
             // Commit using the balance in the contracts, which we just committed.
             const shortTokenSupplyBefore = await shortToken.totalSupply()
+            const settlementBefore = await token.balanceOf(signers[0].address)
             await createCommit(
                 l2Encoder,
                 poolCommitter,
@@ -424,6 +425,10 @@ describe("PoolCommitter - commit", () => {
                 true
             )
             const shortTokenSupplyAfter = await shortToken.totalSupply()
+            const settlementAfter = await token.balanceOf(signers[0].address)
+
+            // Settlement token balance should not change
+            expect(settlementAfter).to.equal(settlementBefore)
 
             const userMostRecentCommit = await getCurrentUserCommit(
                 signers[0].address,
@@ -739,6 +744,8 @@ describe("PoolCommitter - commit", () => {
         it("Should appropriately set values", async () => {
             // Commit using the balance in the contracts, which we just committed.
             const longTokenSupplyBefore = await longToken.totalSupply()
+            const settlementBefore = await token.balanceOf(signers[0].address)
+
             await createCommit(
                 l2Encoder,
                 poolCommitter,
@@ -747,6 +754,10 @@ describe("PoolCommitter - commit", () => {
                 true
             )
             const longTokenSupplyAfter = await longToken.totalSupply()
+            const settlementAfter = await token.balanceOf(signers[0].address)
+
+            // Settlement should not change (this commit is from aggregate balance)
+            expect(settlementAfter).to.equal(settlementBefore)
 
             const userMostRecentCommit = await getCurrentUserCommit(
                 signers[0].address,


### PR DESCRIPTION
# Motivation

Long mint from aggregate balance would attempt to transfer from wallet.

# Changes
- Correct the `if` statement condition in `PoolCommitter::commit` to only take from wallet if `!fromAggregateBalance`