### PR TITLE
Add helpers for `CommitType`

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -111,6 +111,14 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         return t == CommitType.LongBurn || t == CommitType.ShortBurn;
     }
 
+    function isLong(CommitType t) external pure override returns (bool) {
+        return t == CommitType.LongMint || t == CommitType.LongBurn;
+    }
+
+    function isShort(CommitType t) external pure override returns (bool) {
+        return t == CommitType.ShortMint || t == CommitType.ShortBurn;
+    }
+
     /**
      * @notice Initialises the contract
      * @param _factory Address of the associated `PoolFactory` contract

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -103,18 +103,38 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         _;
     }
 
+    /**
+     * @notice Determines whether the provided commitment type represents a
+     *          mint
+     * @return Boolean indicating if `t` is mint
+     */
     function isMint(CommitType t) external pure override returns (bool) {
         return t == CommitType.LongMint || t == CommitType.ShortMint;
     }
 
+    /**
+     * @notice Determines whether the provided commitment type represents a
+     *          burn
+     * @return Boolean indicating if `t` is burn
+     */
     function isBurn(CommitType t) external pure override returns (bool) {
         return t == CommitType.LongBurn || t == CommitType.ShortBurn;
     }
 
+    /**
+     * @notice Determines whether the provided commitment type represents a
+     *          long
+     * @return Boolean indicating if `t` is long
+     */
     function isLong(CommitType t) external pure override returns (bool) {
         return t == CommitType.LongMint || t == CommitType.LongBurn;
     }
 
+    /**
+     * @notice Determines whether the provided commitment type represents a
+     *          short
+     * @return Boolean indicating if `t` is short
+     */
     function isShort(CommitType t) external pure override returns (bool) {
         return t == CommitType.ShortMint || t == CommitType.ShortBurn;
     }

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -204,7 +204,7 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         Balance memory balance = userAggregateBalance[msg.sender];
         uint256 feeAmount;
 
-        if (commitType == CommitType.LongMint || commitType == CommitType.ShortMint) {
+        if (this.isMint(commitType)) {
             // We want to deduct the amount of settlement tokens that will be recorded under the commit by the minting fee
             // and then add it to the correct side of the pool
             feeAmount =

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -103,6 +103,14 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         _;
     }
 
+    function isMint(CommitType t) external pure override returns (bool) {
+        return t == CommitType.LongMint || t == CommitType.ShortMint;
+    }
+
+    function isBurn(CommitType t) external pure override returns (bool) {
+        return t == CommitType.LongBurn || t == CommitType.ShortBurn;
+    }
+
     /**
      * @notice Initialises the contract
      * @param _factory Address of the associated `PoolFactory` contract

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -17,6 +17,10 @@ interface IPoolCommitter {
 
     function isBurn(CommitType t) external pure returns (bool);
 
+    function isLong(CommitType t) external pure returns (bool);
+
+    function isShort(CommitType t) external pure returns (bool);
+
     // Pool balances and supplies
     struct BalancesAndSupplies {
         uint256 newShortBalance;

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -13,6 +13,10 @@ interface IPoolCommitter {
         ShortBurnLongMint // Burn Short tokens, then instantly mint in same upkeep
     }
 
+    function isMint(CommitType t) external pure returns (bool);
+
+    function isBurn(CommitType t) external pure returns (bool);
+
     // Pool balances and supplies
     struct BalancesAndSupplies {
         uint256 newShortBalance;


### PR DESCRIPTION
# Issue
Closes #452 

# Changes

```
$ git log --oneline pools-v2..452-add-commit-type-helpers
5643e45 (HEAD -> 452-add-commit-type-helpers, origin/452-add-commit-type-helpers) Modify `applyCommitment` to use new helpers
6648ff3 Add documentation comments
8530d5e Add additional `CommitType` helpers for market sides
1fc4f6e Add `isMint` and `isBurn` helpers to `IPoolCommitter`
```
