### PR TITLE
Take fees when a user does a flip commit

### DIFF
--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -63,6 +63,8 @@ interface IPoolCommitter {
         uint256 _newLongTokensSum;
         uint256 _newShortTokensSum;
         uint256 _newSettlementTokensSum;
+        uint256 _longSettlementFee;
+        uint256 _shortSettlementFee;
         uint256 _longBurnFee;
         uint256 _shortBurnFee;
         uint8 _maxIterations;

--- a/contracts/interfaces/IPoolCommitter.sol
+++ b/contracts/interfaces/IPoolCommitter.sol
@@ -65,8 +65,6 @@ interface IPoolCommitter {
         uint256 _newSettlementTokensSum;
         uint256 _longSettlementFee;
         uint256 _shortSettlementFee;
-        uint256 _longBurnFee;
-        uint256 _shortBurnFee;
         uint8 _maxIterations;
     }
 

--- a/contracts/libraries/PoolSwapLibrary.sol
+++ b/contracts/libraries/PoolSwapLibrary.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.7;
 
 import "abdk-libraries-solidity/ABDKMathQuad.sol";
-import "hardhat/console.sol";
 
 /// @title Library for various useful (mostly) mathematical functions
 library PoolSwapLibrary {

--- a/contracts/libraries/PoolSwapLibrary.sol
+++ b/contracts/libraries/PoolSwapLibrary.sol
@@ -465,7 +465,7 @@ library PoolSwapLibrary {
         bytes16 mintingFeeRate,
         uint256 amount,
         uint256 amountBurnedInstantMint
-    ) public view returns (uint256, uint256) {
+    ) public pure returns (uint256, uint256) {
         require(price != 0, "price == 0");
         uint256 mintFeeSettlementAmount;
         if (amountBurnedInstantMint > 0) {

--- a/contracts/libraries/PoolSwapLibrary.sol
+++ b/contracts/libraries/PoolSwapLibrary.sol
@@ -41,9 +41,7 @@ library PoolSwapLibrary {
     struct UpdateResult {
         uint256 _newLongTokens; // Quantity of long pool tokens post-application
         uint256 _newShortTokens; // Quantity of short pool tokens post-application
-        uint256 _longBurnFee; // Quantity of settlement tokens taken as a fee from long burns
         uint256 _longSettlementFee; // The fee taken from ShortBurnLongMint commits
-        uint256 _shortBurnFee; // Quantity of settlement tokens taken as a fee from short burns
         uint256 _shortSettlementFee; // The fee taken from ShortBurnLongMint commits
         uint256 _newSettlementTokens; // Quantity of settlement tokens post
     }
@@ -449,43 +447,12 @@ library PoolSwapLibrary {
     }
 
     /**
-     * @notice Calculate the number of pool tokens to mint, given some settlement token amount, a price, and a burn amount from other side for instant mint
-     * @param price The price of a pool token
-     * @param oppositePrice The price of the opposite side's pool token
-     * @param mintingFeeRate PoolCommitter.mintingFee - The amount that is extracted from each mint. Given as the decimal * 10 ^ 18. For example, 60% fee is 0.6 * 10 ^ 18 Fees can be 0.
-     * @param amount The amount of settlement tokens being used to mint
-     * @param amountBurnedInstantMint The amount of pool tokens that were burnt from the opposite side for an instant mint in this side
-     * @return Quantity of pool tokens to mint
-     * @return Quantity of settlement tokens taken for minting fee
-     * @dev Throws if price is zero
-     */
-    function getMintWithBurns(
-        bytes16 price,
-        bytes16 oppositePrice,
-        bytes16 mintingFeeRate,
-        uint256 amount,
-        uint256 amountBurnedInstantMint
-    ) public pure returns (uint256, uint256) {
-        require(price != 0, "price == 0");
-        uint256 mintFeeSettlementAmount;
-        if (amountBurnedInstantMint > 0) {
-            // Calculate amount of settlement tokens generated from the burn.
-            uint256 burnSettlementAmount = getBurn(oppositePrice, amountBurnedInstantMint);
-            // Calculate the amount of fees taken from the upcoming mint.
-            mintFeeSettlementAmount = mintingFee(mintingFeeRate, burnSettlementAmount);
-            burnSettlementAmount -= mintFeeSettlementAmount;
-            amount += burnSettlementAmount;
-        }
-        return (getMint(price, amount), mintFeeSettlementAmount);
-    }
-
-    /**
      * @notice Calculate the amount of settlement tokens to take as the minting fee
-     * @param mintingFeeRate PoolCommitter.mintingFee - The amount that is extracted from each mint. Given as the decimal * 10 ^ 18. For example, 60% fee is 0.6 * 10 ^ 18 Fees can be 0.
+     * @param feeRate PoolCommitter's mintingFee or burningFee - The amount that is extracted from each mint or burn. Given as the decimal * 10 ^ 18. For example, 60% fee is 0.6 * 10 ^ 18 Fees can be 0.
      * @param amount The amount of settlement tokens being committed to mint
      */
-    function mintingFee(bytes16 mintingFeeRate, uint256 amount) public pure returns (uint256) {
-        return ABDKMathQuad.toUInt(multiplyDecimalByUInt(mintingFeeRate, amount)) / WAD_PRECISION;
+    function mintingOrBurningFee(bytes16 feeRate, uint256 amount) public pure returns (uint256) {
+        return ABDKMathQuad.toUInt(multiplyDecimalByUInt(feeRate, amount)) / WAD_PRECISION;
     }
 
     /**
@@ -500,63 +467,121 @@ library PoolSwapLibrary {
     }
 
     /**
+     * @notice Given an amount of pool tokens to flip to the other side of the pool, calculate the amount of settlement tokens generated from the burn, burn fee, and subsequent minting fee
+     * @dev Takes out the burn fee before taking out the mint fee.
+     * @param amount The amount of pool tokens being flipped
+     * @param burnPrice The price of the pool token being burnt
+     * @param burningFee Fee rate for pool token burns
+     * @param mintingFee Fee rate for mints
+     * @return Amount of settlement tokens used to mint.
+     * @return The burn fee. This should be given to the side of the pool of the burnt tokens.
+     * @return The mint fee. This should be given to the side of the pool that is being minted into.
+     */
+    function processBurnInstantMintCommit(
+        uint256 amount,
+        bytes16 burnPrice,
+        bytes16 burningFee,
+        bytes16 mintingFee
+    )
+        public
+        pure
+        returns (
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        // Settlement tokens earned from burning pool tokens (for instant mint)
+        uint256 mintSettlement = getBurn(burnPrice, amount);
+        // The burn fee. This should be given to the side of the pool of the burnt tokens.
+        uint256 burnFee = mintingOrBurningFee(burningFee, mintSettlement);
+        mintSettlement -= burnFee;
+
+        // The mint fee. This should be given to the side of the pool that is being minted into.
+        uint256 mintFee = mintingOrBurningFee(mintingFee, mintSettlement);
+        mintSettlement -= mintFee;
+        return (mintSettlement, burnFee, mintFee);
+    }
+
+    /**
      * @notice Calculate the change in a user's balance based on recent commit(s)
      * @param data Information needed for updating the balance including prices and recent commit amounts
      * @return The UpdateResult struct with the data pertaining to the update of user's aggregate balance
      */
     function getUpdatedAggregateBalance(UpdateData calldata data) external view returns (UpdateResult memory) {
-        UpdateResult memory result = UpdateResult(0, 0, 0, 0, 0, 0, 0);
+        UpdateResult memory result = UpdateResult(0, 0, 0, 0, 0);
         if (data.updateIntervalId >= data.currentUpdateIntervalId) {
             // Update interval has not passed: No change
             return result;
         }
-        if (data.longMintSettlement > 0 || data.shortBurnLongMintPoolTokens > 0) {
-            (result._newLongTokens, result._longSettlementFee) = getMintWithBurns(
-                data.longPrice,
+
+        /**
+         * Start by looking at the "flip" commitments (either LongBurnShortMint, or ShortBurnLongMint), and determine the amount of settlement tokens were generated from them.
+         * Then, take the burning fee off them and add that to the relevant side's fee amount. e.g. a ShortBurnLongMint will generate burn fees for the short side.
+         * Now, we can calculate how much minting fee should be paid by the user. This should then be added to the side which they are minting on.
+         */
+        uint256 shortBurnLongMintResult; // Settlement to be included in the long mint
+        uint256 longBurnShortMintResult; // Settlement to be included in the short mint
+        if (data.shortBurnLongMintPoolTokens > 0) {
+            uint256 burnFeeSettlement;
+            uint256 mintFeeSettlement;
+            (shortBurnLongMintResult, burnFeeSettlement, mintFeeSettlement) = processBurnInstantMintCommit(
+                data.shortBurnLongMintPoolTokens,
                 data.shortPrice,
-                data.mintingFeeRate,
-                data.longMintSettlement,
-                data.shortBurnLongMintPoolTokens
+                data.burnFee,
+                data.mintingFeeRate
             );
+            result._shortSettlementFee += burnFeeSettlement;
+            result._longSettlementFee += mintFeeSettlement;
+        }
+        if (data.longBurnShortMintPoolTokens > 0) {
+            // Settlement tokens earned from burning long tokens (for instant mint)
+            longBurnShortMintResult = getBurn(data.longPrice, data.longBurnShortMintPoolTokens);
+            // The burn fee taken from this burn. This should be given to the long side.
+            uint256 burnFeeSettlement = mintingOrBurningFee(data.burnFee, longBurnShortMintResult);
+            longBurnShortMintResult -= burnFeeSettlement;
+
+            // The mint fee taken from the subsequent mint
+            uint256 mintFeeSettlement = mintingOrBurningFee(data.mintingFeeRate, longBurnShortMintResult);
+            longBurnShortMintResult -= mintFeeSettlement;
+
+            result._longSettlementFee += burnFeeSettlement;
+            result._shortSettlementFee += mintFeeSettlement;
         }
 
-        if (data.longBurnPoolTokens > 0 || data.longBurnShortMintPoolTokens > 0) {
+        /**
+         * Calculate the new long tokens minted.
+         * Use amount committed LongMint/ShortMint, as well as settlement tokens generated from ShortBurnLongMint/LongBurnShortMint commits.
+         */
+        if (data.longMintSettlement > 0 || shortBurnLongMintResult > 0) {
+            result._newLongTokens += getMint(data.longPrice, data.longMintSettlement + shortBurnLongMintResult);
+        }
+        if (data.shortMintSettlement > 0 || longBurnShortMintResult > 0) {
+            result._newShortTokens += getMint(data.shortPrice, data.shortMintSettlement + longBurnShortMintResult);
+        }
+
+        /**
+         * Calculate the settlement tokens earned through LongBurn/ShortBurn commits.
+         * Once this is calculated, take off the burn fee, and add to the respective side's fee amount.
+         */
+        if (data.longBurnPoolTokens > 0) {
             // Calculate the amount of settlement tokens earned from burning long tokens
-            uint256 longBurnResult = getBurn(
-                data.longPrice,
-                data.longBurnPoolTokens + data.longBurnShortMintPoolTokens
-            );
+            uint256 longBurnResult = getBurn(data.longPrice, data.longBurnPoolTokens);
             // Calculate the fee
-            result._longBurnFee =
-                convertDecimalToUInt(multiplyDecimalByUInt(data.burnFee, longBurnResult)) /
-                WAD_PRECISION;
+            uint256 longBurnFee = mintingOrBurningFee(data.burnFee, longBurnResult);
+            result._longSettlementFee += longBurnFee;
             // Subtract the fee from settlement token amount
-            longBurnResult -= result._longBurnFee;
+            longBurnResult -= longBurnFee;
             result._newSettlementTokens += longBurnResult;
         }
-
-        if (data.shortMintSettlement > 0 || data.longBurnShortMintPoolTokens > 0) {
-            (result._newShortTokens, result._shortSettlementFee) = getMintWithBurns(
-                data.shortPrice,
-                data.longPrice,
-                data.mintingFeeRate,
-                data.shortMintSettlement,
-                data.longBurnShortMintPoolTokens
-            );
-        }
-
-        if (data.shortBurnPoolTokens > 0 || data.shortBurnLongMintPoolTokens > 0) {
+        if (data.shortBurnPoolTokens > 0) {
             // Calculate the amount of settlement tokens earned from burning short tokens
-            uint256 shortBurnResult = getBurn(
-                data.shortPrice,
-                data.shortBurnPoolTokens + data.shortBurnLongMintPoolTokens
-            );
+            uint256 shortBurnResult = getBurn(data.shortPrice, data.shortBurnPoolTokens);
             // Calculate the fee
-            result._shortBurnFee =
-                convertDecimalToUInt(multiplyDecimalByUInt(data.burnFee, shortBurnResult)) /
-                WAD_PRECISION;
+            uint256 shortBurnFee = mintingOrBurningFee(data.burnFee, shortBurnResult);
+            result._shortSettlementFee += shortBurnFee;
             // Subtract the fee from settlement token amount
-            shortBurnResult -= result._shortBurnFee;
+            shortBurnResult -= shortBurnFee;
             result._newSettlementTokens += shortBurnResult;
         }
 

--- a/test/PoolCommitter/burningFee.spec.ts
+++ b/test/PoolCommitter/burningFee.spec.ts
@@ -18,6 +18,7 @@ import {
     LONG_MINT,
     POOL_CODE,
     SHORT_BURN,
+    SHORT_BURN_THEN_MINT,
     SHORT_MINT,
 } from "../constants"
 import {
@@ -252,8 +253,122 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
         })
     })
 
+    context("Create SHORT_BURN_LONG_MINT commit", async () => {
+        let shortBurnLongMintFee: BigNumber
+        let mintFee: BigNumber
+        let mintFeeReciprocal: BigNumber
+        let mintFeeAmount: BigNumber
+        beforeEach(async () => {
+            const result = await deployPoolAndTokenContracts(
+                POOL_CODE,
+                frontRunningInterval,
+                updateInterval,
+                leverage,
+                feeAddress,
+                fee,
+                0,
+                burnFee
+            )
+            signers = result.signers
+            pool = result.pool
+            token = result.token
+            library = result.library
+            poolCommitter = result.poolCommitter
+            poolKeeper = result.poolKeeper
+            longToken = result.longToken
+            shortToken = result.shortToken
+            l2Encoder = result.l2Encoder
+
+            mintFee = burnFee
+            mintFeeReciprocal = burnFeeReciprocal
+
+            // The expected fee is the burn fee + the minting fee on the other side. Given that the mint fee == burn fee, we can expect a fee equal to double the burn fee.
+            shortBurnLongMintFee = amountCommitted.div(burnFeeReciprocal).mul(2)
+            mintFeeAmount = amountCommitted.div(mintFeeReciprocal)
+
+            await poolKeeper.setGasPrice("0")
+            await token.approve(pool.address, amountCommitted)
+            await createCommit(
+                l2Encoder,
+                poolCommitter,
+                SHORT_MINT,
+                amountCommitted
+            )
+            // Make the mint fee equal to the burn fee
+            await poolCommitter.setMintingFee(mintFee)
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+            await createCommit(
+                l2Encoder,
+                poolCommitter,
+                SHORT_BURN_THEN_MINT,
+                amountCommitted,
+                true
+            )
+        })
+        it("burns all pool tokens", async () => {
+            expect(await shortToken.totalSupply()).to.equal(0)
+        })
+
+        it("stores the amount committed", async () => {
+            expect(
+                (await getCurrentTotalCommit(poolCommitter))
+                    .shortBurnLongMintPoolTokens
+            ).to.equal(amountCommitted)
+            expect(
+                (await getCurrentUserCommit(signers[0].address, poolCommitter))
+                    .shortBurnLongMintPoolTokens
+            ).to.equal(amountCommitted)
+        })
+
+        it("Updates aggregate balance", async () => {
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+            expect(
+                (await poolCommitter.getAggregateBalance(signers[0].address))
+                    .shortTokens
+            ).to.equal(0)
+            expect(
+                (await poolCommitter.getAggregateBalance(signers[0].address))
+                    .settlementTokens
+            ).to.equal(amountCommitted.sub(shortBurnLongMintFee))
+        })
+
+        it("Updates wallet balance when claiming", async () => {
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+            const settlementBefore = await token.balanceOf(signers[0].address)
+            await poolCommitter.claim(signers[0].address)
+            const settlementAfter = await token.balanceOf(signers[0].address)
+            expect(await shortToken.balanceOf(signers[0].address)).to.equal(0)
+            expect(settlementAfter.sub(settlementBefore)).to.equal(
+                amountCommitted.sub(shortBurnLongMintFee)
+            )
+        })
+
+        it("Updates long and short balance", async () => {
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+
+            const shortBalanceBefore = await pool.shortBalance()
+            const longBalanceBefore = await pool.longBalance()
+            await poolCommitter.claim(signers[0].address)
+            const shortBalanceAfter = await pool.shortBalance()
+            const longBalanceAfter = await pool.longBalance()
+
+            // Short Balance should get short burn fee paid
+            expect(shortBalanceAfter.sub(shortBalanceBefore)).to.equal(feeTaken)
+            // Long balance should get the minting fee added to it
+            expect(longBalanceAfter.sub(longBalanceBefore)).to.equal(
+                mintFeeAmount
+            )
+        })
+    })
     context("Create LONG_BURN_SHORT_MINT commit", async () => {
         let longBurnShortMintFee: BigNumber
+        let mintFee: BigNumber
+        let mintFeeReciprocal: BigNumber
+        let mintFeeAmount: BigNumber
         beforeEach(async () => {
             const result = await deployPoolAndTokenContracts(
                 POOL_CODE,
@@ -274,8 +389,12 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             longToken = result.longToken
             l2Encoder = result.l2Encoder
 
+            mintFee = burnFee
+            mintFeeReciprocal = burnFeeReciprocal
+
             // The expected fee is the burn fee + the minting fee on the other side. Given that the mint fee == burn fee, we can expect a fee equal to double the burn fee.
             longBurnShortMintFee = amountCommitted.div(burnFeeReciprocal).mul(2)
+            mintFeeAmount = amountCommitted.div(mintFeeReciprocal)
 
             await poolKeeper.setGasPrice("0")
             await token.approve(pool.address, amountCommitted)
@@ -286,7 +405,7 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
                 amountCommitted
             )
             // Make the mint fee equal to the burn fee
-            await poolCommitter.setMintingFee(burnFee)
+            await poolCommitter.setMintingFee(mintFee)
             await timeout(updateInterval * 1000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
             await createCommit(
@@ -325,11 +444,34 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             ).to.equal(amountCommitted.sub(longBurnShortMintFee))
         })
 
-        it("Updates wallet balance properly on claim", async () => {
+        it("Updates wallet balance when claiming", async () => {
             await timeout(updateInterval * 1000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
+            const settlementBefore = await token.balanceOf(signers[0].address)
             await poolCommitter.claim(signers[0].address)
+            const settlementAfter = await token.balanceOf(signers[0].address)
             expect(await longToken.balanceOf(signers[0].address)).to.equal(0)
+            expect(settlementAfter.sub(settlementBefore)).to.equal(
+                amountCommitted.sub(longBurnShortMintFee)
+            )
+        })
+
+        it("Updates long and short balance", async () => {
+            await timeout(updateInterval * 1000)
+            await poolKeeper.performUpkeepSinglePool(pool.address)
+
+            const shortBalanceBefore = await pool.shortBalance()
+            const longBalanceBefore = await pool.longBalance()
+            await poolCommitter.claim(signers[0].address)
+            const shortBalanceAfter = await pool.shortBalance()
+            const longBalanceAfter = await pool.longBalance()
+
+            // Long Balance should get long burn fee paid
+            expect(longBalanceAfter.sub(longBalanceBefore)).to.equal(feeTaken)
+            // Short balance should get the minting fee added to it
+            expect(shortBalanceAfter.sub(shortBalanceBefore)).to.equal(
+                mintFeeAmount
+            )
         })
     })
 })

--- a/test/PoolCommitter/burningFee.spec.ts
+++ b/test/PoolCommitter/burningFee.spec.ts
@@ -283,9 +283,13 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             mintFeeReciprocal = burnFeeReciprocal
 
             // Burn fee taken out, then mint fee taken out
-            mintFeeAmount = (amountCommitted.sub(amountCommitted.div(burnFeeReciprocal))).div(mintFeeReciprocal)
+            mintFeeAmount = amountCommitted
+                .sub(amountCommitted.div(burnFeeReciprocal))
+                .div(mintFeeReciprocal)
             // The expected fee is the burn fee + the minting fee on the other side. Given that the mint fee == burn fee, we can expect a fee equal to the (amountCommitted / BurnFee) + (amountCommittedAfterBurnFee / mintFee)
-            shortBurnLongMintFee = amountCommitted.div(burnFeeReciprocal).add(mintFeeAmount)
+            shortBurnLongMintFee = amountCommitted
+                .div(burnFeeReciprocal)
+                .add(mintFeeAmount)
 
             await poolKeeper.setGasPrice("0")
             await token.approve(pool.address, amountCommitted)
@@ -354,14 +358,12 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             expect(await shortToken.balanceOf(signers[0].address)).to.equal(0)
 
             // Long tokens should increment, because we instantly mint them from the burn
-            expect(
-                (await longToken.balanceOf(signers[0].address))
-            ).to.equal(amountCommitted.sub(shortBurnLongMintFee))
+            expect(await longToken.balanceOf(signers[0].address)).to.equal(
+                amountCommitted.sub(shortBurnLongMintFee)
+            )
 
             // Given that we are using all the settlement tokens generated from the short burn to instantly mint, we should expect no change to settlement token amount
-            expect(settlementAfter.sub(settlementBefore)).to.equal(
-                0
-            )
+            expect(settlementAfter.sub(settlementBefore)).to.equal(0)
         })
 
         it("Updates long and short balance", async () => {
@@ -412,9 +414,13 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             mintFeeReciprocal = burnFeeReciprocal
 
             // Burn fee taken out, then mint fee taken out
-            mintFeeAmount = (amountCommitted.sub(amountCommitted.div(burnFeeReciprocal))).div(mintFeeReciprocal)
+            mintFeeAmount = amountCommitted
+                .sub(amountCommitted.div(burnFeeReciprocal))
+                .div(mintFeeReciprocal)
             // The expected fee is the burn fee + the minting fee on the other side. Given that the mint fee == burn fee, we can expect a fee equal to the (amountCommitted / BurnFee) + (amountCommittedAfterBurnFee / mintFee)
-            longBurnShortMintFee = amountCommitted.div(burnFeeReciprocal).add(mintFeeAmount)
+            longBurnShortMintFee = amountCommitted
+                .div(burnFeeReciprocal)
+                .add(mintFeeAmount)
 
             await poolKeeper.setGasPrice("0")
             await token.approve(pool.address, amountCommitted)
@@ -473,15 +479,17 @@ describe("PoolCommitter - Burn commit with burn fee", () => {
             await timeout(updateInterval * 1000)
             await poolKeeper.performUpkeepSinglePool(pool.address)
             const settlementBefore = await token.balanceOf(signers[0].address)
-            const shortTokenBefore = await shortToken.balanceOf(signers[0].address)
+            const shortTokenBefore = await shortToken.balanceOf(
+                signers[0].address
+            )
             await poolCommitter.claim(signers[0].address)
-            const shortTokenAfter = await shortToken.balanceOf(signers[0].address)
+            const shortTokenAfter = await shortToken.balanceOf(
+                signers[0].address
+            )
             const settlementAfter = await token.balanceOf(signers[0].address)
 
             expect(await longToken.balanceOf(signers[0].address)).to.equal(0)
-            expect(settlementAfter.sub(settlementBefore)).to.equal(
-                0
-            )
+            expect(settlementAfter.sub(settlementBefore)).to.equal(0)
             expect(shortTokenAfter.sub(shortTokenBefore)).to.equal(
                 amountCommitted.sub(longBurnShortMintFee)
             )

--- a/test/PoolCommitter/commit.spec.ts
+++ b/test/PoolCommitter/commit.spec.ts
@@ -1075,6 +1075,7 @@ describe("PoolCommitter - commit", () => {
                 shortToken = result.shortToken
                 longToken = result.longToken
                 poolCommitter = result.poolCommitter
+                l2Encoder = result.l2Encoder
 
                 await token.approve(pool.address, amountCommitted.mul(999))
                 await pool.setKeeper(signers[0].address)
@@ -1284,11 +1285,18 @@ describe("PoolCommitter - commit", () => {
                         signers[0].address
                     )
 
+                    const settlementTokenBefore = await token.balanceOf(signers[0].address)
+
                     await poolCommitter.claim(signers[0].address)
 
                     const shortBalanceAfter = await shortToken.balanceOf(
                         signers[0].address
                     )
+
+                    const settlementTokenAfter = await token.balanceOf(signers[0].address)
+
+                    // Settlement token should not increase, because you're using all settlement to re-commit to other side
+                    expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
 
                     expect(shortBalanceAfter.sub(shortBalanceBefore)).to.equal(
                         amountCommitted
@@ -1338,7 +1346,14 @@ describe("PoolCommitter - commit", () => {
                         signers[0].address
                     )
 
+                    const settlementTokenBefore = await token.balanceOf(signers[0].address)
+
                     await poolCommitter.claim(signers[0].address)
+
+                    const settlementTokenAfter = await token.balanceOf(signers[0].address)
+
+                    // Settlement token should not increase, because you're using all settlement to re-commit to other side
+                    expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
 
                     const shortBalanceAfter = await shortToken.balanceOf(
                         signers[0].address
@@ -1848,7 +1863,14 @@ describe("PoolCommitter - commit", () => {
                     signers[0].address
                 )
 
+                const settlementTokenBefore = await token.balanceOf(signers[0].address)
+
                 await poolCommitter.claim(signers[0].address)
+
+                const settlementTokenAfter = await token.balanceOf(signers[0].address)
+
+                // Settlement token should not increase, because you're using all settlement to re-commit to other side
+                expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
 
                 const longBalanceAfter = await longToken.balanceOf(
                     signers[0].address
@@ -1894,7 +1916,14 @@ describe("PoolCommitter - commit", () => {
                     signers[0].address
                 )
 
+                const settlementTokenBefore = await token.balanceOf(signers[0].address)
+
                 await poolCommitter.claim(signers[0].address)
+
+                const settlementTokenAfter = await token.balanceOf(signers[0].address)
+
+                // Settlement token should not increase, because you're using all settlement to re-commit to other side
+                expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
 
                 const longBalanceAfter = await longToken.balanceOf(
                     signers[0].address

--- a/test/PoolCommitter/commit.spec.ts
+++ b/test/PoolCommitter/commit.spec.ts
@@ -1285,7 +1285,9 @@ describe("PoolCommitter - commit", () => {
                         signers[0].address
                     )
 
-                    const settlementTokenBefore = await token.balanceOf(signers[0].address)
+                    const settlementTokenBefore = await token.balanceOf(
+                        signers[0].address
+                    )
 
                     await poolCommitter.claim(signers[0].address)
 
@@ -1293,10 +1295,14 @@ describe("PoolCommitter - commit", () => {
                         signers[0].address
                     )
 
-                    const settlementTokenAfter = await token.balanceOf(signers[0].address)
+                    const settlementTokenAfter = await token.balanceOf(
+                        signers[0].address
+                    )
 
                     // Settlement token should not increase, because you're using all settlement to re-commit to other side
-                    expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
+                    expect(
+                        settlementTokenAfter.sub(settlementTokenBefore)
+                    ).to.equal(0)
 
                     expect(shortBalanceAfter.sub(shortBalanceBefore)).to.equal(
                         amountCommitted
@@ -1346,14 +1352,20 @@ describe("PoolCommitter - commit", () => {
                         signers[0].address
                     )
 
-                    const settlementTokenBefore = await token.balanceOf(signers[0].address)
+                    const settlementTokenBefore = await token.balanceOf(
+                        signers[0].address
+                    )
 
                     await poolCommitter.claim(signers[0].address)
 
-                    const settlementTokenAfter = await token.balanceOf(signers[0].address)
+                    const settlementTokenAfter = await token.balanceOf(
+                        signers[0].address
+                    )
 
                     // Settlement token should not increase, because you're using all settlement to re-commit to other side
-                    expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
+                    expect(
+                        settlementTokenAfter.sub(settlementTokenBefore)
+                    ).to.equal(0)
 
                     const shortBalanceAfter = await shortToken.balanceOf(
                         signers[0].address
@@ -1863,14 +1875,20 @@ describe("PoolCommitter - commit", () => {
                     signers[0].address
                 )
 
-                const settlementTokenBefore = await token.balanceOf(signers[0].address)
+                const settlementTokenBefore = await token.balanceOf(
+                    signers[0].address
+                )
 
                 await poolCommitter.claim(signers[0].address)
 
-                const settlementTokenAfter = await token.balanceOf(signers[0].address)
+                const settlementTokenAfter = await token.balanceOf(
+                    signers[0].address
+                )
 
                 // Settlement token should not increase, because you're using all settlement to re-commit to other side
-                expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
+                expect(
+                    settlementTokenAfter.sub(settlementTokenBefore)
+                ).to.equal(0)
 
                 const longBalanceAfter = await longToken.balanceOf(
                     signers[0].address
@@ -1916,14 +1934,20 @@ describe("PoolCommitter - commit", () => {
                     signers[0].address
                 )
 
-                const settlementTokenBefore = await token.balanceOf(signers[0].address)
+                const settlementTokenBefore = await token.balanceOf(
+                    signers[0].address
+                )
 
                 await poolCommitter.claim(signers[0].address)
 
-                const settlementTokenAfter = await token.balanceOf(signers[0].address)
+                const settlementTokenAfter = await token.balanceOf(
+                    signers[0].address
+                )
 
                 // Settlement token should not increase, because you're using all settlement to re-commit to other side
-                expect(settlementTokenAfter.sub(settlementTokenBefore)).to.equal(0)
+                expect(
+                    settlementTokenAfter.sub(settlementTokenBefore)
+                ).to.equal(0)
 
                 const longBalanceAfter = await longToken.balanceOf(
                     signers[0].address

--- a/test/PoolCommitter/executeCommitment/longBurn.spec.ts
+++ b/test/PoolCommitter/executeCommitment/longBurn.spec.ts
@@ -38,7 +38,7 @@ const frontRunningInterval = 100 // seconds
 const fee = DEFAULT_FEE
 const leverage = 2
 
-describe("LeveragedPool - executeCommitment: Long Burn", () => {
+describe("PoolCommitter - executeCommitment: Long Burn", () => {
     let token: TestToken
 
     let longToken: ERC20

--- a/test/PoolCommitter/executeCommitment/longBurnShortMint.spec.ts
+++ b/test/PoolCommitter/executeCommitment/longBurnShortMint.spec.ts
@@ -44,7 +44,7 @@ const mintFeeReciprocal = ethers.BigNumber.from("100")
 const burnFeeReciprocal = ethers.BigNumber.from("100")
 const leverage = 2
 
-describe("LeveragedPool - executeCommitment: Long Burn into instant short mint", () => {
+describe("PoolCommitter - executeCommitment: Long Burn into instant short mint", () => {
     let token: TestToken
 
     let longToken: ERC20

--- a/test/PoolCommitter/executeCommitment/longBurnShortMint.spec.ts
+++ b/test/PoolCommitter/executeCommitment/longBurnShortMint.spec.ts
@@ -88,9 +88,13 @@ describe("LeveragedPool - executeCommitment: Long Burn into instant short mint",
         await poolCommitter.setMintingFee(mintFee)
 
         // Burn fee taken out, then mint fee taken out
-        mintFeeAmount = (amountCommitted.sub(amountCommitted.div(burnFeeReciprocal))).div(mintFeeReciprocal)
+        mintFeeAmount = amountCommitted
+            .sub(amountCommitted.div(burnFeeReciprocal))
+            .div(mintFeeReciprocal)
         // The expected fee is the burn fee + the minting fee on the other side. Given that the mint fee == burn fee, we can expect a fee equal to the (amountCommitted / BurnFee) + (amountCommittedAfterBurnFee / mintFee)
-        longBurnShortMintFee = amountCommitted.div(burnFeeReciprocal).add(mintFeeAmount)
+        longBurnShortMintFee = amountCommitted
+            .div(burnFeeReciprocal)
+            .add(mintFeeAmount)
 
         await timeout(updateInterval * 1000)
         await pool.poolUpkeep(9, 10)
@@ -107,13 +111,17 @@ describe("LeveragedPool - executeCommitment: Long Burn into instant short mint",
         expect(await shortToken.totalSupply()).to.eq(0)
         await timeout(updateInterval * 1000)
         await pool.poolUpkeep(9, 9)
-        expect(await shortToken.totalSupply()).to.eq(amountCommitted.sub(longBurnShortMintFee))
+        expect(await shortToken.totalSupply()).to.eq(
+            amountCommitted.sub(longBurnShortMintFee)
+        )
     })
     it("should adjust the live short pool balance", async () => {
         expect(await pool.longBalance()).to.eq(amountCommitted)
         await timeout(updateInterval * 1000)
         await pool.poolUpkeep(9, 9)
-        expect(await pool.shortBalance()).to.eq(amountCommitted.sub(longBurnShortMintFee))
+        expect(await pool.shortBalance()).to.eq(
+            amountCommitted.sub(longBurnShortMintFee)
+        )
     })
     it("should adjust the live long pool balance", async () => {
         expect(await pool.longBalance()).to.eq(amountCommitted)
@@ -123,7 +131,8 @@ describe("LeveragedPool - executeCommitment: Long Burn into instant short mint",
     })
     it("should reduce the shadow long burn short mint pool balance", async () => {
         expect(
-            (await getCurrentTotalCommit(poolCommitter)).longBurnShortMintPoolTokens
+            (await getCurrentTotalCommit(poolCommitter))
+                .longBurnShortMintPoolTokens
         ).to.equal(amountCommitted)
         await timeout(updateInterval * 1000)
         await pool.poolUpkeep(9, 9)
@@ -147,14 +156,12 @@ describe("LeveragedPool - executeCommitment: Long Burn into instant short mint",
     })
 
     it("should transfer short tokens to the commit owner", async () => {
-        expect(await shortToken.balanceOf(signers[0].address)).to.eq(
-            0
-        )
+        expect(await shortToken.balanceOf(signers[0].address)).to.eq(0)
         await timeout(updateInterval * 1000)
         await pool.poolUpkeep(9, 9)
         await poolCommitter.claim(signers[0].address)
-        expect(
-            await shortToken.balanceOf(signers[0].address)
-        ).to.eq(amountCommitted.sub(longBurnShortMintFee))
+        expect(await shortToken.balanceOf(signers[0].address)).to.eq(
+            amountCommitted.sub(longBurnShortMintFee)
+        )
     })
 })

--- a/test/PoolCommitter/executeCommitment/longBurnShortMint.spec.ts
+++ b/test/PoolCommitter/executeCommitment/longBurnShortMint.spec.ts
@@ -1,0 +1,160 @@
+import { ethers } from "hardhat"
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+import {
+    LeveragedPool,
+    TestToken,
+    ERC20,
+    PoolSwapLibrary,
+    PoolCommitter,
+    L2Encoder,
+} from "../../../types"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import {
+    DEFAULT_FEE,
+    DEFAULT_MINT_AMOUNT,
+    LONG_BURN,
+    LONG_BURN_THEN_MINT,
+    LONG_MINT,
+    POOL_CODE,
+    SHORT_MINT,
+} from "../../constants"
+import {
+    deployPoolAndTokenContracts,
+    generateRandomAddress,
+    createCommit,
+    CommitEventArgs,
+    timeout,
+    getCurrentTotalCommit,
+} from "../../utilities"
+import { BigNumber } from "ethers"
+
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const amountCommitted = ethers.utils.parseEther("2000")
+const amountMinted = ethers.BigNumber.from(DEFAULT_MINT_AMOUNT)
+const feeAddress = generateRandomAddress()
+const updateInterval = 200
+const frontRunningInterval = 100 // seconds
+const fee = DEFAULT_FEE
+const burnFee = ethers.utils.parseEther("0.01")
+const mintFee = ethers.utils.parseEther("0.01")
+const mintFeeReciprocal = ethers.BigNumber.from("100")
+const burnFeeReciprocal = ethers.BigNumber.from("100")
+const leverage = 2
+
+describe("LeveragedPool - executeCommitment: Long Burn into instant short mint", () => {
+    let token: TestToken
+
+    let longToken: ERC20
+    let shortToken: ERC20
+    let poolCommitter: PoolCommitter
+    let pool: LeveragedPool
+    let signers: SignerWithAddress[]
+    let commit: CommitEventArgs
+    let library: PoolSwapLibrary
+    let l2Encoder: L2Encoder
+    let mintFeeAmount: BigNumber
+    let longBurnShortMintFee: BigNumber
+    beforeEach(async () => {
+        const result = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee,
+            0,
+            burnFee
+        )
+        pool = result.pool
+        signers = result.signers
+        token = result.token
+        library = result.library
+        longToken = result.longToken
+        shortToken = result.shortToken
+        poolCommitter = result.poolCommitter
+        l2Encoder = result.l2Encoder
+        await pool.setKeeper(signers[0].address)
+        await token.approve(pool.address, amountMinted)
+        commit = await createCommit(
+            l2Encoder,
+            poolCommitter,
+            [LONG_MINT],
+            amountCommitted
+        )
+
+        await poolCommitter.setMintingFee(mintFee)
+
+        // Burn fee taken out, then mint fee taken out
+        mintFeeAmount = (amountCommitted.sub(amountCommitted.div(burnFeeReciprocal))).div(mintFeeReciprocal)
+        // The expected fee is the burn fee + the minting fee on the other side. Given that the mint fee == burn fee, we can expect a fee equal to the (amountCommitted / BurnFee) + (amountCommittedAfterBurnFee / mintFee)
+        longBurnShortMintFee = amountCommitted.div(burnFeeReciprocal).add(mintFeeAmount)
+
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 10)
+        await poolCommitter.claim(signers[0].address)
+        await longToken.approve(pool.address, amountCommitted)
+        commit = await createCommit(
+            l2Encoder,
+            poolCommitter,
+            [LONG_BURN_THEN_MINT],
+            amountCommitted
+        )
+    })
+    it("should mint short pool tokens", async () => {
+        expect(await shortToken.totalSupply()).to.eq(0)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(await shortToken.totalSupply()).to.eq(amountCommitted.sub(longBurnShortMintFee))
+    })
+    it("should adjust the live short pool balance", async () => {
+        expect(await pool.longBalance()).to.eq(amountCommitted)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(await pool.shortBalance()).to.eq(amountCommitted.sub(longBurnShortMintFee))
+    })
+    it("should adjust the live long pool balance", async () => {
+        expect(await pool.longBalance()).to.eq(amountCommitted)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(await pool.longBalance()).to.eq(0)
+    })
+    it("should reduce the shadow long burn short mint pool balance", async () => {
+        expect(
+            (await getCurrentTotalCommit(poolCommitter)).longBurnShortMintPoolTokens
+        ).to.equal(amountCommitted)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(
+            await (
+                await getCurrentTotalCommit(poolCommitter)
+            ).longBurnShortMintPoolTokens
+        ).to.eq(0)
+    })
+    it("should not transfer settlement tokens to the commit owner, because we are instantly minting", async () => {
+        expect(await token.balanceOf(signers[0].address)).to.eq(
+            amountMinted.sub(amountCommitted)
+        )
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        const tokensBefore = await token.balanceOf(signers[0].address)
+        await poolCommitter.claim(signers[0].address)
+        expect(
+            (await token.balanceOf(signers[0].address)).sub(tokensBefore)
+        ).to.eq(0)
+    })
+
+    it("should transfer short tokens to the commit owner", async () => {
+        expect(await shortToken.balanceOf(signers[0].address)).to.eq(
+            0
+        )
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        await poolCommitter.claim(signers[0].address)
+        expect(
+            await shortToken.balanceOf(signers[0].address)
+        ).to.eq(amountCommitted.sub(longBurnShortMintFee))
+    })
+})

--- a/test/PoolCommitter/executeCommitment/longMint.spec.ts
+++ b/test/PoolCommitter/executeCommitment/longMint.spec.ts
@@ -30,7 +30,7 @@ const frontRunningInterval = 100 // seconds
 const fee = DEFAULT_FEE
 const leverage = 2
 
-describe("LeveragedPool - executeCommitment: Long Mint", () => {
+describe("PoolCommitter - executeCommitment: Long Mint", () => {
     let token: TestToken
     let longToken: ERC20
     let pool: LeveragedPool

--- a/test/PoolCommitter/executeCommitment/multipleCommitments.spec.ts
+++ b/test/PoolCommitter/executeCommitment/multipleCommitments.spec.ts
@@ -44,7 +44,7 @@ const frontRunningInterval = 100 // seconds
 const fee = DEFAULT_FEE
 const leverage = 1
 
-describe("LeveragedPool - executeCommitment:  Multiple commitments", () => {
+describe("PoolCommitter - executeCommitment:  Multiple commitments", () => {
     let token: TestToken
     let shortToken: ERC20
     let pool: LeveragedPool

--- a/test/PoolCommitter/executeCommitment/shortBurn.spec.ts
+++ b/test/PoolCommitter/executeCommitment/shortBurn.spec.ts
@@ -39,7 +39,7 @@ const frontRunningInterval = 100 // seconds
 const fee = DEFAULT_FEE
 const leverage = 2
 
-describe("LeveragedPool - executeCommitment: Short Burn", () => {
+describe("PoolCommitter - executeCommitment: Short Burn", () => {
     let token: TestToken
     let shortToken: ERC20
     let library: PoolSwapLibrary

--- a/test/PoolCommitter/executeCommitment/shortBurnLongMint.spec.ts
+++ b/test/PoolCommitter/executeCommitment/shortBurnLongMint.spec.ts
@@ -1,0 +1,164 @@
+import { ethers } from "hardhat"
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+import {
+    LeveragedPool,
+    TestToken,
+    ERC20,
+    PoolSwapLibrary,
+    PoolCommitter,
+    L2Encoder,
+} from "../../../types"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import {
+    DEFAULT_FEE,
+    DEFAULT_MINT_AMOUNT,
+    SHORT_BURN_THEN_MINT,
+    POOL_CODE,
+    SHORT_MINT,
+} from "../../constants"
+import {
+    deployPoolAndTokenContracts,
+    generateRandomAddress,
+    createCommit,
+    CommitEventArgs,
+    timeout,
+    getCurrentTotalCommit,
+} from "../../utilities"
+import { BigNumber } from "ethers"
+
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const amountCommitted = ethers.utils.parseEther("2000")
+const amountMinted = ethers.BigNumber.from(DEFAULT_MINT_AMOUNT)
+const feeAddress = generateRandomAddress()
+const updateInterval = 200
+const frontRunningInterval = 100 // seconds
+const fee = DEFAULT_FEE
+const burnFee = ethers.utils.parseEther("0.01")
+const mintFee = ethers.utils.parseEther("0.01")
+const mintFeeReciprocal = ethers.BigNumber.from("100")
+const burnFeeReciprocal = ethers.BigNumber.from("100")
+const leverage = 2
+
+describe("PoolCommitter - executeCommitment: short burn into instant short mint", () => {
+    let token: TestToken
+
+    let shortToken: ERC20
+    let longToken: ERC20
+    let poolCommitter: PoolCommitter
+    let pool: LeveragedPool
+    let signers: SignerWithAddress[]
+    let commit: CommitEventArgs
+    let l2Encoder: L2Encoder
+    let mintFeeAmount: BigNumber
+    let shortBurnLongMintFee: BigNumber
+    beforeEach(async () => {
+        const result = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee,
+            0,
+            burnFee
+        )
+        pool = result.pool
+        signers = result.signers
+        token = result.token
+        library = result.library
+        shortToken = result.shortToken
+        longToken = result.longToken
+        poolCommitter = result.poolCommitter
+        l2Encoder = result.l2Encoder
+        await pool.setKeeper(signers[0].address)
+        await token.approve(pool.address, amountMinted)
+        commit = await createCommit(
+            l2Encoder,
+            poolCommitter,
+            [SHORT_MINT],
+            amountCommitted
+        )
+
+        await poolCommitter.setMintingFee(mintFee)
+
+        // Burn fee taken out, then mint fee taken out
+        mintFeeAmount = amountCommitted
+            .sub(amountCommitted.div(burnFeeReciprocal))
+            .div(mintFeeReciprocal)
+        // The expected fee is the burn fee + the minting fee on the other side. Given that the mint fee == burn fee, we can expect a fee equal to the (amountCommitted / BurnFee) + (amountCommittedAfterBurnFee / mintFee)
+        shortBurnLongMintFee = amountCommitted
+            .div(burnFeeReciprocal)
+            .add(mintFeeAmount)
+
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 10)
+        await poolCommitter.claim(signers[0].address)
+        await shortToken.approve(pool.address, amountCommitted)
+        commit = await createCommit(
+            l2Encoder,
+            poolCommitter,
+            [SHORT_BURN_THEN_MINT],
+            amountCommitted
+        )
+    })
+    it("should mint short pool tokens", async () => {
+        expect(await longToken.totalSupply()).to.eq(0)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(await longToken.totalSupply()).to.eq(
+            amountCommitted.sub(shortBurnLongMintFee)
+        )
+    })
+    it("should adjust the live long pool balance", async () => {
+        expect(await pool.shortBalance()).to.eq(amountCommitted)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(await pool.longBalance()).to.eq(
+            amountCommitted.sub(shortBurnLongMintFee)
+        )
+    })
+    it("should adjust the live short pool balance", async () => {
+        expect(await pool.shortBalance()).to.eq(amountCommitted)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(await pool.shortBalance()).to.eq(0)
+    })
+    it("should reduce the shadow short burn short mint pool balance", async () => {
+        expect(
+            (await getCurrentTotalCommit(poolCommitter))
+                .shortBurnLongMintPoolTokens
+        ).to.equal(amountCommitted)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        expect(
+            await (
+                await getCurrentTotalCommit(poolCommitter)
+            ).shortBurnLongMintPoolTokens
+        ).to.eq(0)
+    })
+    it("should not transfer settlement tokens to the commit owner, because we are instantly minting", async () => {
+        expect(await token.balanceOf(signers[0].address)).to.eq(
+            amountMinted.sub(amountCommitted)
+        )
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        const tokensBefore = await token.balanceOf(signers[0].address)
+        await poolCommitter.claim(signers[0].address)
+        expect(
+            (await token.balanceOf(signers[0].address)).sub(tokensBefore)
+        ).to.eq(0)
+    })
+
+    it("should transfer long tokens to the commit owner", async () => {
+        expect(await longToken.balanceOf(signers[0].address)).to.eq(0)
+        await timeout(updateInterval * 1000)
+        await pool.poolUpkeep(9, 9)
+        await poolCommitter.claim(signers[0].address)
+        expect(await longToken.balanceOf(signers[0].address)).to.eq(
+            amountCommitted.sub(shortBurnLongMintFee)
+        )
+    })
+})

--- a/test/PoolCommitter/executeCommitment/shortBurnLongMint.spec.ts
+++ b/test/PoolCommitter/executeCommitment/shortBurnLongMint.spec.ts
@@ -68,7 +68,6 @@ describe("PoolCommitter - executeCommitment: short burn into instant short mint"
         pool = result.pool
         signers = result.signers
         token = result.token
-        library = result.library
         shortToken = result.shortToken
         longToken = result.longToken
         poolCommitter = result.poolCommitter

--- a/test/PoolCommitter/executeCommitment/shortMint.spec.ts
+++ b/test/PoolCommitter/executeCommitment/shortMint.spec.ts
@@ -31,7 +31,7 @@ const frontRunningInterval = 100 // seconds
 const fee = DEFAULT_FEE
 const leverage = 2
 
-describe("LeveragedPool - executeCommitment: Short Mint", () => {
+describe("PoolCommitter - executeCommitment: Short Mint", () => {
     let token: TestToken
     let shortToken: ERC20
     let pool: LeveragedPool


### PR DESCRIPTION
Closes #454 
# Motivation
When a user commits to either a `LongBurnShortMint` or `ShortBurnLongMint`, they are not charged the burning and subsequent minting fee

# Changes
- Given that minting fee is usually taken at commit time, we needed to do some tricky stuff with the library function involving passing the minting fee rate into the library.
- Now, we pass the minting fee into the library function for updating balance (`getUpdatedAggregateBalance`), and return the settlement fee to be used to add to either the `longBalance` or the `shortBalance`.
- There were lots of parameters being thrown around, and we ended up exceeding the maximum number of returnable parameters. This was fixed by returning a `struct` instead.

**Executing commitments**
- Now that we are actually charging fees on flip commits, we need to account for what the fees _will_ be for each user **when we are executing the commitments**. This means we have to change how we calculate the result of a `*Burn*Mint` commit.
    - This "changing" of how it is calculated basically just means take out the burn fee from the first burn, and the mint fee from the subsequent mint.

# Approval Requirements

To ensure this code has been properly analyzed, before approving this PR, you must write out a short answer to the following question:
**What is the point of the `if` block of code located on[ this line in `PoolSwapLibrary`](https://github.com/tracer-protocol/perpetual-pools-contracts/pull/454/files#diff-d3fb3ed88c633a5798bb1ee2468701cbcc4cfccaa5774f12589af31127ef8461R525)?**