### PR TITLE
Cap changeInterval at 100%

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -185,7 +185,7 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         changeInterval = PoolSwapLibrary.convertUIntToDecimal(_changeInterval);
         require(mintingFee <= MAX_MINTING_FEE, "Minting fee exceeds limit");
         require(burningFee <= MAX_BURNING_FEE, "Burning fee exceeds limit");
-        //         require(changeInterval <= MAX_CHANGE_INTERVAL, "changeInterval exceeds limit");
+        require(changeInterval <= MAX_CHANGE_INTERVAL, "Change Interval exceeds limit");
 
         feeController = _feeController;
         autoClaim = IAutoClaim(_autoClaim);
@@ -923,6 +923,7 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
      */
     function setChangeInterval(uint256 _changeInterval) external override onlyFeeController {
         changeInterval = PoolSwapLibrary.convertUIntToDecimal(_changeInterval);
+        require(changeInterval <= MAX_CHANGE_INTERVAL, "Change Interval exceeds limit");
         emit ChangeIntervalSet(_changeInterval);
     }
 

--- a/contracts/libraries/PoolSwapLibrary.sol
+++ b/contracts/libraries/PoolSwapLibrary.sol
@@ -15,12 +15,6 @@ library PoolSwapLibrary {
     /// Maximum precision supportable via wad arithmetic (for this contract)
     uint256 public constant WAD_PRECISION = 10**18;
 
-    // Set max minting fee to 100%. This is a ABDKQuad representation of 1 * 10 ** 18
-    bytes16 public constant MAX_MINTING_FEE = 0x403abc16d674ec800000000000000000;
-
-    // Set max burning fee to 10%. This is a ABDKQuad representation of 0.1 * 10 ** 18
-    bytes16 public constant MAX_BURNING_FEE = 0x40376345785d8a000000000000000000;
-
     /// Information required to update a given user's aggregated balance
     struct UpdateData {
         bytes16 longPrice;


### PR DESCRIPTION
# Motivation
The theoretical largest change in `mintingFee` that could happen in a single update interval is by `100%` (either moving from 100% minting fee to 0%, or vise-versa).
Therefore, we can set the maximum `PoolCommitter::changeInterval` to be 100%.

This also eliminates possibilities of `changeInterval` being so large that arithmetic overflows.

# Changes
- Add `bytes16 public constant MAX_CHANGE_INTERVAL = MAX_MINTING_FEE;`