### PR TITLE
Role based access control

### DIFF
--- a/contracts/implementation/AutoClaim.sol
+++ b/contracts/implementation/AutoClaim.sol
@@ -20,7 +20,7 @@ contract AutoClaim is IAutoClaim {
     IPoolFactory internal immutable poolFactory;
 
     modifier onlyPoolCommitter() {
-        require(poolFactory.isValidPoolCommitter(msg.sender), "msg.sender not valid PoolCommitter");
+        require(poolFactory.hasPoolCommitterRole(msg.sender), "msg.sender not valid PoolCommitter");
         _;
     }
 
@@ -75,7 +75,7 @@ contract AutoClaim is IAutoClaim {
      * @param poolCommitterAddress The PoolCommitter address within which the user's claim will be executed
      */
     function paidClaim(address user, address poolCommitterAddress) public override {
-        require(poolFactory.isValidPoolCommitter(poolCommitterAddress), "Invalid pool committer contract");
+        require(poolFactory.hasPoolCommitterRole(poolCommitterAddress), "Invalid pool committer contract");
         IPoolCommitter poolCommitter = IPoolCommitter(poolCommitterAddress);
         uint256 currentUpdateIntervalId = poolCommitter.updateIntervalId();
         uint256 reward = claim(user, poolCommitterAddress, poolCommitter, currentUpdateIntervalId);
@@ -152,7 +152,7 @@ contract AutoClaim is IAutoClaim {
             poolCommitterAddress = CalldataLogic.getAddressAtOffset(poolCommittersOffset);
 
             // Make sure this PoolCommitter is one which has been deployed by the factory
-            require(poolFactory.isValidPoolCommitter(poolCommitterAddress), "Invalid pool committer contract");
+            require(poolFactory.hasPoolCommitterRole(poolCommitterAddress), "Invalid pool committer contract");
             IPoolCommitter poolCommitter = IPoolCommitter(poolCommitterAddress);
 
             // Get the update interval ID of the pool committer we are using
@@ -192,7 +192,7 @@ contract AutoClaim is IAutoClaim {
 
         address user;
         uint256 reward;
-        require(poolFactory.isValidPoolCommitter(poolCommitterAddress), "Invalid pool committer contract");
+        require(poolFactory.hasPoolCommitterRole(poolCommitterAddress), "Invalid pool committer contract");
         IPoolCommitter poolCommitter = IPoolCommitter(poolCommitterAddress);
         uint256 currentUpdateIntervalId = poolCommitter.updateIntervalId();
         for (uint256 i; i < nrUsers; ) {
@@ -215,7 +215,7 @@ contract AutoClaim is IAutoClaim {
      * @dev Emits a `RequestWithdrawn` event on success
      */
     function withdrawClaimRequest(address poolCommitter) external override {
-        require(poolFactory.isValidPoolCommitter(poolCommitter), "Invalid pool committer contract");
+        require(poolFactory.hasPoolCommitterRole(poolCommitter), "Invalid pool committer contract");
         if (claimRequests[msg.sender][poolCommitter].updateIntervalId > 0) {
             uint256 reward = claimRequests[msg.sender][poolCommitter].reward;
             delete claimRequests[msg.sender][poolCommitter];

--- a/contracts/implementation/InvariantCheck.sol
+++ b/contracts/implementation/InvariantCheck.sol
@@ -32,7 +32,7 @@ contract InvariantCheck is IInvariantCheck {
      */
     function checkInvariants(address poolToCheck) external override {
         ILeveragedPool pool = ILeveragedPool(poolToCheck);
-        require(poolFactory.isValidPool(poolToCheck), "Pool is invalid");
+        require(poolFactory.hasPoolRole(poolToCheck), "Pool is invalid");
         IPoolCommitter poolCommitter = IPoolCommitter(pool.poolCommitter());
         uint256 poolBalance = IERC20(pool.settlementToken()).balanceOf(poolToCheck);
         uint256 pendingMints = poolCommitter.pendingMintSettlementAmount();

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -316,10 +316,20 @@ contract PoolFactory is IPoolFactory, ITwoStepGovernance, AccessControl {
         emit FeeChanged(_fee);
     }
 
+    /**
+     * @notice Gets if the address has the "POOL_ROLE" role
+     * @param pool Address to check the role against
+     * @return Boolean indicating if the address has the "POOL_ROLE" role
+     */
     function hasPoolRole(address pool) external view override returns (bool) {
         return hasRole(POOL_ROLE, pool);
     }
 
+    /**
+     * @notice Gets if the address has the "POOL_COMMITTER_ROLE" role
+     * @param poolCommitter Address to check the role against
+     * @return Boolean indicating if the address has the "POOL_COMMITTER_ROLE" role
+     */
     function hasPoolCommitterRole(address poolCommitter) external view override returns (bool) {
         return hasRole(POOL_COMMITTER_ROLE, poolCommitter);
     }

--- a/contracts/implementation/PoolFactory.sol
+++ b/contracts/implementation/PoolFactory.sol
@@ -366,7 +366,9 @@ contract PoolFactory is IPoolFactory, ITwoStepGovernance, AccessControl {
         address _provisionalGovernance = provisionalGovernance;
         require(msg.sender == _provisionalGovernance, "Not provisional governor");
         address oldGovernance = governance; /* for later event emission */
+        _revokeRole(GOVERNANCE_ROLE, oldGovernance);
         governance = _provisionalGovernance;
+         _grantRole(GOVERNANCE_ROLE, governance);
         governanceTransferInProgress = false;
         emit GovernanceAddressChanged(oldGovernance, _provisionalGovernance);
     }

--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -210,7 +210,7 @@ contract PoolKeeper is IPoolKeeper, AccessControl {
     
     /**
      * @notice Gets if the address has the "KEEPER_REWARDS_ROLE" role
-     * @param pool Address to check the role against
+     * @param _keeperRewards Address to check the role against
      * @return Boolean indicating if the address has the "KEEPER_REWARDS_ROLE" role
      */
     function hasKeeperRewardsRole(address _keeperRewards) external view override returns (bool) {

--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -10,7 +10,7 @@ import "../interfaces/IKeeperRewards.sol";
 
 import "../libraries/CalldataLogic.sol";
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
 import "abdk-libraries-solidity/ABDKMathQuad.sol";
 
 /// @title The manager contract for multiple markets and the pools in them
@@ -19,7 +19,7 @@ import "abdk-libraries-solidity/ABDKMathQuad.sol";
 /// @dev This code was also written with Arbitrum deployment in mind, meaning there exists no `block.basefee`, and no arbitrum gas price oracle.
 /// @dev It has another large drawback in that it is not possible to calculate the cost of the current transaction Arbitrum, given that the cost is largely determined by L1 calldata cost.
 /// @dev Because of this, the reward calculation is an rough "good enough" estimation.
-contract PoolKeeper is IPoolKeeper, Ownable {
+contract PoolKeeper is IPoolKeeper, AccessControl {
     // #### Global variables
     /**
      * @notice Format: Pool address => last executionPrice
@@ -28,22 +28,20 @@ contract PoolKeeper is IPoolKeeper, Ownable {
 
     IPoolFactory public immutable factory;
     // The KeeperRewards contract permissioned to pay out pool upkeep rewards
-    address public override keeperRewards;
+    address public keeperRewards;
+    
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+    bytes32 public constant FACTORY_ROLE = keccak256("FACTORY_ROLE");
+    bytes32 public constant KEEPER_REWARDS_ROLE = keccak256("KEEPER_REWARDS_ROLE");
 
     uint256 public gasPrice = 10 gwei;
-
-    /**
-     * @notice Ensures that the caller is the associated `PoolFactory` contract
-     */
-    modifier onlyFactory() {
-        require(msg.sender == address(factory), "Caller not factory");
-        _;
-    }
 
     // #### Functions
     constructor(address _factory) {
         require(_factory != address(0), "Factory cannot be null");
         factory = IPoolFactory(_factory);
+        _grantRole(FACTORY_ROLE, _factory);
+        _grantRole(OWNER_ROLE, msg.sender);
     }
 
     /**
@@ -51,7 +49,7 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @param _poolAddress The address of the newly-created pools
      * @dev Only callable by the associated `PoolFactory` contract
      */
-    function newPool(address _poolAddress) external override onlyFactory {
+    function newPool(address _poolAddress) external override onlyRole(FACTORY_ROLE) {
         IOracleWrapper(ILeveragedPool(_poolAddress).oracleWrapper()).poll();
         int256 firstPrice = ILeveragedPool(_poolAddress).getOraclePrice();
         require(firstPrice > 0, "First price is non-positive");
@@ -65,7 +63,7 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @return Whether or not upkeep is needed for this single pool
      */
     function isUpkeepRequiredSinglePool(address _pool) public view override returns (bool) {
-        if (!factory.isValidPool(_pool)) {
+        if (!factory.hasPoolRole(_pool)) {
             return false;
         }
 
@@ -175,10 +173,12 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @dev Only callable by the contract owner
      * @dev emits KeeperRewardsSet when the addresss is successfuly changed
      */
-    function setKeeperRewards(address _keeperRewards) external override onlyOwner {
+    function setKeeperRewards(address _keeperRewards) external override onlyRole(OWNER_ROLE) {
         require(_keeperRewards != address(0), "KeeperRewards cannot be 0 address");
         address oldKeeperRewards = keeperRewards;
+        _revokeRole(KEEPER_REWARDS_ROLE, oldKeeperRewards);
         keeperRewards = _keeperRewards;
+        _grantRole(KEEPER_REWARDS_ROLE, keeperRewards);
         emit KeeperRewardsSet(oldKeeperRewards, _keeperRewards);
     }
 
@@ -208,6 +208,10 @@ contract PoolKeeper is IPoolKeeper, Ownable {
         }
     }
 
+    function hasKeeperRewardsRole(address _keeperRewards) external view override returns (bool) {
+        return hasRole(KEEPER_REWARDS_ROLE, _keeperRewards);
+    }
+
     /**
      * @notice Sets the gas price to be used in compensating keepers for successful upkeep
      * @param _price Price (in ETH) per unit gas
@@ -215,7 +219,7 @@ contract PoolKeeper is IPoolKeeper, Ownable {
      * @dev This function is only necessary due to the L2 deployment of Pools -- in reality, it should be `BASEFEE`
      * @dev Emits a `GasPriceChanged` event on success
      */
-    function setGasPrice(uint256 _price) external override onlyOwner {
+    function setGasPrice(uint256 _price) external override onlyRole(OWNER_ROLE) {
         gasPrice = _price;
         emit GasPriceChanged(_price);
     }

--- a/contracts/implementation/PoolKeeper.sol
+++ b/contracts/implementation/PoolKeeper.sol
@@ -207,7 +207,12 @@ contract PoolKeeper is IPoolKeeper, AccessControl {
             }
         }
     }
-
+    
+    /**
+     * @notice Gets if the address has the "KEEPER_REWARDS_ROLE" role
+     * @param pool Address to check the role against
+     * @return Boolean indicating if the address has the "KEEPER_REWARDS_ROLE" role
+     */
     function hasKeeperRewardsRole(address _keeperRewards) external view override returns (bool) {
         return hasRole(KEEPER_REWARDS_ROLE, _keeperRewards);
     }

--- a/contracts/interfaces/IPoolFactory.sol
+++ b/contracts/interfaces/IPoolFactory.sol
@@ -96,10 +96,6 @@ interface IPoolFactory {
 
     function numPools() external view returns (uint256);
 
-    function isValidPool(address _pool) external view returns (bool);
-
-    function isValidPoolCommitter(address _poolCommitter) external view returns (bool);
-
     function getPoolKeeper() external view returns (address);
 
     // #### Functions
@@ -116,4 +112,8 @@ interface IPoolFactory {
     function setFee(uint256 _fee) external;
 
     function setSecondaryFeeSplitPercent(uint256 newFeePercent) external;
+
+    function hasPoolRole(address pool) external view returns (bool);
+
+    function hasPoolCommitterRole(address poolCommitter) external view returns (bool);
 }

--- a/contracts/interfaces/IPoolKeeper.sol
+++ b/contracts/interfaces/IPoolKeeper.sol
@@ -62,10 +62,6 @@ interface IPoolKeeper {
      */
     event GasPriceChanged(uint256 indexed price);
 
-    // #### Variables
-
-    function keeperRewards() external returns (address);
-
     // #### Functions
     function newPool(address _poolAddress) external;
 
@@ -82,4 +78,6 @@ interface IPoolKeeper {
     function setGasPrice(uint256 _price) external;
 
     function performUpkeepMultiplePoolsPacked(bytes calldata pools) external;
+
+    function hasKeeperRewardsRole(address _keeperRewards) external view returns (bool);
 }

--- a/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
+++ b/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
@@ -314,10 +314,20 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, ITwoStepGovernance, Access
         emit FeeChanged(_fee);
     }
 
+    /**
+     * @notice Gets if the address has the "POOL_ROLE" role
+     * @param pool Address to check the role against
+     * @return Boolean indicating if the address has the "POOL_ROLE" role
+     */
     function hasPoolRole(address pool) external view override returns (bool) {
         return hasRole(POOL_ROLE, pool);
     }
 
+    /**
+     * @notice Gets if the address has the "POOL_COMMITTER_ROLE" role
+     * @param poolCommitter Address to check the role against
+     * @return Boolean indicating if the address has the "POOL_COMMITTER_ROLE" role
+     */
     function hasPoolCommitterRole(address poolCommitter) external view override returns (bool) {
         return hasRole(POOL_COMMITTER_ROLE, poolCommitter);
     }

--- a/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
+++ b/contracts/test-utilities/PoolFactoryBalanceDrainMock.sol
@@ -364,7 +364,9 @@ contract PoolFactoryBalanceDrainMock is IPoolFactory, ITwoStepGovernance, Access
         address _provisionalGovernance = provisionalGovernance;
         require(msg.sender == _provisionalGovernance, "Not provisional governor");
         address oldGovernance = governance; /* for later event emission */
+        _revokeRole(GOVERNANCE_ROLE, oldGovernance);
         governance = _provisionalGovernance;
+         _grantRole(GOVERNANCE_ROLE, governance);
         governanceTransferInProgress = false;
         emit GovernanceAddressChanged(oldGovernance, _provisionalGovernance);
     }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     },
     "dependencies": {
         "@chainlink/contracts": "^0.2.1",
-        "@openzeppelin/contracts": "^4.2.0",
+        "@openzeppelin/contracts": "^4.6.0",
         "abdk-libraries-solidity": "^3.0.0",
         "hardhat": "^2.6.0",
         "hardhat-log-remover": "^2.0.2",

--- a/test/InvariantCheck/balanceInvariant.spec.ts
+++ b/test/InvariantCheck/balanceInvariant.spec.ts
@@ -196,9 +196,7 @@ describe("InvariantCheck - balanceInvariant", () => {
                 await timeout(updateInterval * 2000)
 
                 await pool.setKeeper(signers[0].address)
-                await expect(pool.poolUpkeep(10, 10)).to.be.revertedWith(
-                    "Pool is paused"
-                )
+                await expect(pool.poolUpkeep(10, 10)).to.be.reverted
             })
         }
     )
@@ -268,12 +266,10 @@ describe("InvariantCheck - balanceInvariant", () => {
             expect(await pool.paused()).to.equal(true)
             expect(await poolCommitter.paused()).to.equal(true)
 
-            await expect(pool.connect(signers[1]).unpause()).to.be.revertedWith(
-                "msg.sender not governance"
-            )
+            await expect(pool.connect(signers[1]).unpause()).to.be.reverted
             await expect(
                 poolCommitter.connect(signers[1]).unpause()
-            ).to.be.revertedWith("msg.sender not governance")
+            ).to.be.reverted
             expect(await pool.paused()).to.equal(true)
             expect(await poolCommitter.paused()).to.equal(true)
         })

--- a/test/LeveragedPool/setters.spec.ts
+++ b/test/LeveragedPool/setters.spec.ts
@@ -37,7 +37,7 @@ describe("LeveragedPool - setters", async () => {
             await pool.updateFeeAddress(signers[1].address)
             await expect(
                 pool.connect(signers[2]).updateFeeAddress(signers[2].address)
-            ).to.be.revertedWith("msg.sender not governance")
+            ).to.be.reverted
         })
     })
 
@@ -51,7 +51,7 @@ describe("LeveragedPool - setters", async () => {
             await pool.setKeeper(signers[1].address)
             await expect(
                 pool.connect(signers[2]).setKeeper(signers[2].address)
-            ).to.be.revertedWith("msg.sender not governance")
+            ).to.be.reverted
         })
     })
 
@@ -64,7 +64,7 @@ describe("LeveragedPool - setters", async () => {
             await pool.transferGovernance(signers[1].address)
             await expect(
                 pool.connect(signers[2]).transferGovernance(signers[2].address)
-            ).to.be.rejectedWith("msg.sender not governance")
+            ).to.be.rejected
         })
     })
 

--- a/test/PoolCommitter/executeCommitment/baseCases.spec.ts
+++ b/test/PoolCommitter/executeCommitment/baseCases.spec.ts
@@ -173,7 +173,7 @@ describe("poolCommitter - executeCommitment: Basic test cases", () => {
             await timeout(updateInterval * 1000)
             await expect(
                 pool.connect(signers[1]).poolUpkeep(9, 10)
-            ).to.be.revertedWith("msg.sender not keeper")
+            ).to.be.reverted
         })
     })
 })

--- a/test/PoolFactory/setters.spec.ts
+++ b/test/PoolFactory/setters.spec.ts
@@ -37,7 +37,7 @@ describe("PoolFactory - setters", async () => {
             await factory.setFeeReceiver(signers[1].address)
             await expect(
                 factory.connect(signers[2]).setFeeReceiver(signers[2].address)
-            ).to.be.revertedWith("msg.sender not governance")
+            ).to.be.reverted
         })
     })
 
@@ -51,7 +51,7 @@ describe("PoolFactory - setters", async () => {
             await factory.setPoolKeeper(signers[1].address)
             await expect(
                 factory.connect(signers[2]).setPoolKeeper(signers[2].address)
-            ).to.be.revertedWith("msg.sender not governance")
+            ).to.be.reverted
         })
     })
 
@@ -68,7 +68,7 @@ describe("PoolFactory - setters", async () => {
                 factory
                     .connect(signers[2])
                     .transferGovernance(signers[2].address)
-            ).to.be.rejectedWith("msg.sender not governance")
+            ).to.be.rejected
         })
     })
 

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -84,7 +84,7 @@ describe("LeveragedPool - executeAllCommitments", () => {
             await pool.setKeeper(signers[0].address)
             await expect(
                 pool.connect(signers[1]).poolUpkeep(9, 10)
-            ).to.be.revertedWith("msg.sender not keeper")
+            ).to.be.reverted
             // Doesn't delete commit
             const updateIntervalId = await poolCommitter.updateIntervalId()
             expect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,10 +982,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.2.0.tgz"
-  integrity sha512-LD4NnkKpHHSMo5z9MvFsG4g1xxZUDqV3A3Futu3nvyfs4wPwXxqOgMaxOoa2PeyGL2VNeSlbxT54enbQzGcgJQ==
+"@openzeppelin/contracts@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
+  integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
 
 "@openzeppelin/hardhat-upgrades@^1.8.2":
   version "1.9.0"


### PR DESCRIPTION
Dework task: https://app.dework.xyz/tracer-dao/engineering-4?taskId=2af40775-e5b7-426e-80cb-79d0db106bd4

Modify contracts to use the OpenZeppelin Access Control library.

Regex matching for Chai is only available on an unstable version so the string matching needed to be cut for some of the revertedWith tests.