### PR TITLE
Update lastPriceTimestamp before fee payment

### DIFF
--- a/contracts/libraries/PoolSwapLibrary.sol
+++ b/contracts/libraries/PoolSwapLibrary.sol
@@ -573,7 +573,7 @@ library PoolSwapLibrary {
      * @param data Information needed for updating the balance including prices and recent commit amounts
      * @return The UpdateResult struct with the data pertaining to the update of user's aggregate balance
      */
-    function getUpdatedAggregateBalance(UpdateData calldata data) external view returns (UpdateResult memory) {
+    function getUpdatedAggregateBalance(UpdateData calldata data) external pure returns (UpdateResult memory) {
         UpdateResult memory result = UpdateResult(0, 0, 0, 0, 0);
         if (data.updateIntervalId >= data.currentUpdateIntervalId) {
             // Update interval has not passed: No change


### PR DESCRIPTION
# Motivation

`poolUpkeep` does not implement the checks-effects-interactions pattern, it is possible to re-enter the function and satisfy the intervalPassed() check again.

# Changes
- We don't know how much `lastPriceTimestamp` will increase until `PoolCommitter::executeCommitments` has finished executing, but we can increment it by `updateInterval` to prevent a reentrancy because we know that `lastPriceTimestamp` will increase by at least this amount.