### PR TITLE
Make sure settlementTOkenPrice >= 0

### DIFF
--- a/contracts/implementation/KeeperRewards.sol
+++ b/contracts/implementation/KeeperRewards.sol
@@ -54,6 +54,8 @@ contract KeeperRewards is IKeeperRewards {
         }
         int256 settlementTokenPrice = IOracleWrapper(ILeveragedPool(_pool).settlementEthOracle()).getPrice();
 
+        require(settlementTokenPrice >= 0, "settlement price must be >= 0");
+
         uint256 reward = keeperReward(
             _pool,
             _gasPrice,


### PR DESCRIPTION
# Motivation
The `payKeeper()` function performs an unsafe cast of the `settlementTokenPrice` variable. This may lead to an
unlikely edge case where arithmetic underflows are not properly handled by the protocol.

# Changes
- Add a value check like in the [OZ SafeCast library](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/math/SafeCast.sol#L135).