### PR TITLE
Permission `SMAOracle::poll` to `PoolKeeper` only

### DIFF
--- a/contracts/implementation/SMAOracle.sol
+++ b/contracts/implementation/SMAOracle.sol
@@ -239,11 +239,6 @@ contract SMAOracle is IOracleWrapper {
         }
     }
 
-    modifier onlyDeployer() {
-        require(msg.sender == deployer, "SMA: Only callable by deployer");
-        _;
-    }
-
     modifier onlyGov() {
         require(msg.sender == governance, "SMA: Only callable by governance");
         _;

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -437,6 +437,7 @@ describe("PoolFactory.deployPool", () => {
                 oracleWrapper.address,
                 5,
                 1,
+                await signers[0].getAddress(),
                 await signers[0].getAddress()
             )
             await smaOracle.deployed()
@@ -445,6 +446,9 @@ describe("PoolFactory.deployPool", () => {
                 await smaOracle.poll()
                 await timeout(1000)
             }
+
+            /* correct the PoolKeeper address now that we've performed setup */
+            smaOracle.setPoolKeeper(poolKeeper.address)
 
             const deploymentParameters = {
                 poolName: POOL_CODE,

--- a/test/PoolFactory/deployPool.spec.ts
+++ b/test/PoolFactory/deployPool.spec.ts
@@ -438,6 +438,7 @@ describe("PoolFactory.deployPool", () => {
                 5,
                 1,
                 await signers[0].getAddress(),
+                await signers[0].getAddress(),
                 await signers[0].getAddress()
             )
             await smaOracle.deployed()

--- a/test/SMAOracle/getPrice.spec.ts
+++ b/test/SMAOracle/getPrice.spec.ts
@@ -69,6 +69,7 @@ describe("SMAOracle - getPrice", () => {
             numPeriods,
             updateInterval,
             owner.address,
+            owner.address,
             owner.address
         )
         await smaOracle.deployed()

--- a/test/SMAOracle/getPrice.spec.ts
+++ b/test/SMAOracle/getPrice.spec.ts
@@ -8,7 +8,14 @@ import {
     TestChainlinkOracle__factory,
     SMAOracle__factory,
     ChainlinkOracleWrapper__factory,
+    PoolKeeper__factory,
+    PoolKeeper,
 } from "../../types"
+import { POOL_CODE } from "../constants"
+import {
+    deployPoolAndTokenContracts,
+    generateRandomAddress,
+} from "../utilities"
 
 describe("SMAOracle - getPrice", () => {
     let owner: SignerWithAddress
@@ -16,8 +23,13 @@ describe("SMAOracle - getPrice", () => {
     let user2: SignerWithAddress
     let smaOracle: SMAOracle
     let chainlinkOracle: TestChainlinkOracle
+    let poolKeeper: PoolKeeper
     const numPeriods: BigNumberish = 10
     const updateInterval: BigNumberish = 60
+    const frontRunningInterval: BigNumberish = 10
+    const leverage: BigNumberish = 1
+    const fee: BigNumberish = 1
+    const feeAddress = generateRandomAddress()
 
     beforeEach(async () => {
         ;[owner, user1, user2] = await ethers.getSigners()
@@ -38,6 +50,17 @@ describe("SMAOracle - getPrice", () => {
             )
         await chainlinkOracleWrapper.deployed()
 
+        /* deploy main contracts */
+        const contracts = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee
+        )
+        poolKeeper = contracts.poolKeeper
+
         const SMAOracleFactory = (await ethers.getContractFactory(
             "SMAOracle"
         )) as SMAOracle__factory
@@ -45,6 +68,7 @@ describe("SMAOracle - getPrice", () => {
             chainlinkOracleWrapper.address,
             numPeriods,
             updateInterval,
+            owner.address,
             owner.address
         )
         await smaOracle.deployed()

--- a/test/SMAOracle/getPriceAndMetadata.spec.ts
+++ b/test/SMAOracle/getPriceAndMetadata.spec.ts
@@ -69,6 +69,7 @@ describe("SMAOracle - getPriceAndMetadata", () => {
             numPeriods,
             updateInterval,
             owner.address,
+            owner.address,
             owner.address
         )
         await smaOracle.deployed()

--- a/test/SMAOracle/poll.spec.ts
+++ b/test/SMAOracle/poll.spec.ts
@@ -8,7 +8,14 @@ import {
     TestChainlinkOracle__factory,
     SMAOracle__factory,
     ChainlinkOracleWrapper__factory,
+    PoolKeeper__factory,
+    PoolKeeper,
 } from "../../types"
+import { POOL_CODE } from "../constants"
+import {
+    deployPoolAndTokenContracts,
+    generateRandomAddress,
+} from "../utilities"
 
 describe("SMAOracle - getPrice", () => {
     let owner: SignerWithAddress
@@ -16,8 +23,14 @@ describe("SMAOracle - getPrice", () => {
     let user2: SignerWithAddress
     let smaOracle: SMAOracle
     let chainlinkOracle: TestChainlinkOracle
+    let poolKeeper: PoolKeeper
+    let signers: SignerWithAddress[]
     const numPeriods: BigNumberish = 10
     const updateInterval: BigNumberish = 60
+    const frontRunningInterval: BigNumberish = 10
+    const leverage: BigNumberish = 1
+    const fee: BigNumberish = 1
+    const feeAddress = generateRandomAddress()
 
     beforeEach(async () => {
         ;[owner, user1, user2] = await ethers.getSigners()
@@ -38,6 +51,17 @@ describe("SMAOracle - getPrice", () => {
             )
         await chainlinkOracleWrapper.deployed()
 
+        /* deploy main contracts */
+        const contracts = await deployPoolAndTokenContracts(
+            POOL_CODE,
+            frontRunningInterval,
+            updateInterval,
+            leverage,
+            feeAddress,
+            fee
+        )
+        poolKeeper = contracts.poolKeeper
+
         const SMAOracleFactory = (await ethers.getContractFactory(
             "SMAOracle"
         )) as SMAOracle__factory
@@ -45,6 +69,7 @@ describe("SMAOracle - getPrice", () => {
             chainlinkOracleWrapper.address,
             numPeriods,
             updateInterval,
+            owner.address,
             owner.address
         )
         await smaOracle.deployed()

--- a/test/SMAOracle/poll.spec.ts
+++ b/test/SMAOracle/poll.spec.ts
@@ -70,6 +70,7 @@ describe("SMAOracle - getPrice", () => {
             numPeriods,
             updateInterval,
             owner.address,
+            owner.address,
             owner.address
         )
         await smaOracle.deployed()


### PR DESCRIPTION
# Issue #
Sigma Prime TPP08

# Changes

```
$ git log --oneline pools-v2..sigma-tpp08
4f14bc0 (HEAD -> sigma-tpp08, origin/sigma-tpp08) Permission
```

 - `SMAOracle` now knows about the address of `PoolKeeper`
 - `SMAOracle` has an `onlyDeployer` modifier
 - `SMAOracle` has an `onlyPoolKeeper` modifier
 - `SMAOracle::poll` now has the above modifier
 