### PR TITLE
set `lastPriceTimestamp` to `block.timestamp` if all intervals upkept

### DIFF
--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -647,7 +647,10 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
         // if we maxed out the number of intervals upkept and lastPriceTimestamp is more than `updateInterval` seconds ago
         // it means there are more intervals to upkeep
         // counter will be MAX_ITERATIONS + 1 if we hit max iterations because of the loop condition `while (counter <= MAX_ITERATIONS)`
-        if (counter > MAX_ITERATIONS && (block.timestamp - (lastPriceTimestamp + updateInterval * (counter - 1))) > updateInterval) {
+        if (
+            counter > MAX_ITERATIONS &&
+            (block.timestamp - (lastPriceTimestamp + updateInterval * (counter - 1))) > updateInterval
+        ) {
             // shift lastPriceTimestamp so next time the executeCommitments() will continue where it left off
             lastPriceTimestamp = lastPriceTimestamp + updateInterval * (counter - 1);
         } else {

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -628,17 +628,14 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
                 emit ExecutedCommitsForInterval(executionTracking._updateIntervalId, burningFee);
                 delete totalPoolCommitments[executionTracking._updateIntervalId];
 
-                // counter overflowing would require an unrealistic number of update intervals
+                // counter overflowing would require an unrealistic number of update intervals to be updated
+                // This wouldn't fit in a block, anyway.
                 unchecked {
                     updateIntervalId += 1;
+                    counter += 1;
                 }
             } else {
                 break;
-            }
-            // counter overflowing would require an unrealistic number of update intervals to be updated
-            // This wouldn't fit in a block, anyway.
-            unchecked {
-                counter += 1;
             }
         }
 
@@ -647,9 +644,10 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
             PoolSwapLibrary.getPrice(shortBalance, executionTracking.shortTotalSupply)
         );
 
-        // Subtract counter by 1 to accurately reflect how many update intervals were executed
-        if (block.timestamp >= lastPriceTimestamp + updateInterval * (counter - 1)) {
-            // check if finished
+        // if we maxed out the number of intervals upkept and lastPriceTimestamp is more than `updateInterval` seconds ago
+        // it means there are more intervals to upkeep
+        // counter will be MAX_ITERATIONS + 1 if we hit max iterations because of the loop condition `while (counter <= MAX_ITERATIONS)`
+        if (counter > MAX_ITERATIONS && (block.timestamp - (lastPriceTimestamp + updateInterval * (counter - 1))) > updateInterval) {
             // shift lastPriceTimestamp so next time the executeCommitments() will continue where it left off
             lastPriceTimestamp = lastPriceTimestamp + updateInterval * (counter - 1);
         } else {

--- a/contracts/implementation/PoolCommitter.sol
+++ b/contracts/implementation/PoolCommitter.sol
@@ -644,7 +644,7 @@ contract PoolCommitter is IPoolCommitter, IPausable, Initializable {
             PoolSwapLibrary.getPrice(shortBalance, executionTracking.shortTotalSupply)
         );
 
-        // if we maxed out the number of intervals upkept and lastPriceTimestamp is more than `updateInterval` seconds ago
+        // if we maxed out the number of intervals upkept and projected lastPriceTimestamp is more than `updateInterval` seconds ago
         // it means there are more intervals to upkeep
         // counter will be MAX_ITERATIONS + 1 if we hit max iterations because of the loop condition `while (counter <= MAX_ITERATIONS)`
         if (


### PR DESCRIPTION
# Motivation
We had a bug where `lastPriceTimestamp` was not being set to `block.timestamp` when upkeep brought us fully up to date on outstanding intervals

# Changes
Ensure that if there are no additional intervals to be upkept at the end of upkeep, `lastPriceTimestamp` gets set to the current time