### PR TITLE
Add deployment of keeper rewards

### DIFF
--- a/deploy/ArbitrumDeploy.js
+++ b/deploy/ArbitrumDeploy.js
@@ -139,9 +139,7 @@ module.exports = async (hre) => {
         "KeeperRewards",
         { libraries: { PoolSwapLibrary: library.address } }
     )
-    let keeperRewards = await KeeperRewardsFactory.deploy(
-        poolKeeper.address
-    )
+    let keeperRewards = await KeeperRewardsFactory.deploy(poolKeeper.address)
 
     await execute(
         "PoolKeeper",
@@ -311,8 +309,8 @@ module.exports = async (hre) => {
         address: factory.address,
         constructorArguments: [multisigAddress],
         libraries: {
-            PoolSwapLibrary: library.address
-        }
+            PoolSwapLibrary: library.address,
+        },
     })
 
     // Commented out because if fails if already verified. Need to only do it once or modify to not failed if already verified

--- a/deploy/ArbitrumDeploy.js
+++ b/deploy/ArbitrumDeploy.js
@@ -188,7 +188,7 @@ module.exports = async (hre) => {
     )
 
     console.log("Setting factory fee")
-    const fee = ethers.utils.parseEther("0.03")
+    const fee = ethers.utils.parseEther("0.01")
     await execute(
         "PoolFactory",
         {


### PR DESCRIPTION
# Motivation

`PoolKeeper` needs a `KeeperRewards` contract deployed for it to set `keeperRewards` storage variable. This wasn't being done previously.

# Changes
### `deploy/ArbitrumDeploy.js`
- deploy keeperRewards and set
- Add correct deployment params to `PoolFactory` deployment.